### PR TITLE
Run all package tests from project root

### DIFF
--- a/cmd/sorg-build/main_test.go
+++ b/cmd/sorg-build/main_test.go
@@ -3,11 +3,11 @@ package main
 import (
 	"database/sql"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/brandur/sorg"
+	_ "github.com/brandur/sorg/testing"
 	_ "github.com/lib/pq"
 	assert "github.com/stretchr/testify/require"
 )
@@ -15,14 +15,7 @@ import (
 var db *sql.DB
 
 func init() {
-	// Move up into the project's root so that we in the right place relatively
-	// to content/view/layout/etc. directories.
-	err := os.Chdir("../../")
-	if err != nil {
-		panic(err)
-	}
-
-	err = sorg.CreateTargetDirs()
+	err := sorg.CreateTargetDirs()
 	if err != nil {
 		panic(err)
 	}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,0 +1,33 @@
+package testing
+
+import (
+	"flag"
+	"os"
+	"path"
+	"runtime"
+	"testing"
+
+	"github.com/brandur/sorg"
+)
+
+func init() {
+	// Initializes logrus logging if tests are run with `go test -v`. Note that
+	// command line flags need to be parsed before testing.Verbose() becomes
+	// available.
+	flag.Parse()
+	if testing.Verbose() {
+		sorg.InitLog(true)
+	}
+
+	// Move up into the project's root so that we in the right place relatively
+	// to content/view/layout/etc. directories. The invocation to runtime
+	// returns *this* file (testing.go), and we can then trace up to the
+	// project's root directory no matter what package is being tested (tests
+	// have their CWD set to the project's path).
+	_, filename, _, _ := runtime.Caller(0)
+	path.Join(path.Dir(filename), "..")
+	err := os.Chdir("../../")
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Adds a testing package which provides a generic way to run all tests
from the project's root. This is pretty generically useful because we
depend on content, views, layouts, etc. directories that only exist in
one place.

The testing package should be include via:

``` go
_ "github.com/brandur/sorg/testing"
```

(Note the preceding underscore so that naming doesn't clash with the
regular testing package.)