### PR TITLE
Add tests for ensureSymlink

### DIFF
--- a/cmd/sorg-build/main.go
+++ b/cmd/sorg-build/main.go
@@ -890,7 +890,7 @@ func linkImageAssets() error {
 			return err
 		}
 
-		err = ensureSymbolicLink(source, dest)
+		err = ensureSymlink(source, dest)
 		if err != nil {
 			return err
 		}
@@ -1644,7 +1644,7 @@ func isHidden(file string) bool {
 	return strings.HasPrefix(file, ".")
 }
 
-func ensureSymbolicLink(source, dest string) error {
+func ensureSymlink(source, dest string) error {
 	log.Debugf("Checking symbolic link (%v): %v -> %v",
 		path.Base(source), source, dest)
 

--- a/cmd/sorg-build/main_test.go
+++ b/cmd/sorg-build/main_test.go
@@ -229,7 +229,7 @@ func TestCompileTwitter(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestEnsureSymbolicLink(t *testing.T) {
+func TestEnsureSymlink(t *testing.T) {
 	dir, err := ioutil.TempDir("", "symlink")
 	assert.NoError(t, err)
 
@@ -243,7 +243,7 @@ func TestEnsureSymbolicLink(t *testing.T) {
 	// Case 1: Symlink does not exist
 	//
 
-	err = ensureSymbolicLink(source, dest)
+	err = ensureSymlink(source, dest)
 	assert.NoError(t, err)
 
 	actual, err := os.Readlink(dest)
@@ -255,7 +255,7 @@ func TestEnsureSymbolicLink(t *testing.T) {
 	// Consists solely of re-running the previous test case.
 	//
 
-	err = ensureSymbolicLink(source, dest)
+	err = ensureSymlink(source, dest)
 	assert.NoError(t, err)
 
 	actual, err = os.Readlink(dest)
@@ -272,7 +272,7 @@ func TestEnsureSymbolicLink(t *testing.T) {
 	err = ioutil.WriteFile(source, []byte("source"), 0755)
 	assert.NoError(t, err)
 
-	err = ensureSymbolicLink(source, dest)
+	err = ensureSymlink(source, dest)
 	assert.NoError(t, err)
 
 	actual, err = os.Readlink(dest)


### PR DESCRIPTION
Add some testing for all possible execution paths, which can in some cases be somewhat non-obvious.

Also renames instances of "SymbolicLink" to "Symlink" to follow Golang naming convention more closely.