### PR TITLE
Reorganize fragments index to look more like reading

### DIFF
--- a/content/stylesheets/fragments.sass
+++ b/content/stylesheets/fragments.sass
@@ -19,6 +19,9 @@ $secondary: #cdcdcd
     // with more).
     max-width: 1500px
 
+    // Required to show TOC.
+    position: relative
+
     // this is a "highlight" image that may or may not be included with an
     // article
     img#mood
@@ -47,9 +50,47 @@ $secondary: #cdcdcd
     font-size: 0.75rem
     font-style: italic
 
+  .page-intro
+    font-size: 0.85rem
+
+  // Fragments list
+  #fragments
+    font-size: 0.85rem
+
+    ul
+      column-width: 280px
+      -moz-column-width: 280px
+      -webkit-column-width: 280px
+
+      li
+        margin: 0
+
+        .meta
+          color: $secondary
+          font-family: $sans_serif
+          font-size: 0.75rem
+
+  #toc
+    margin: 0 30px 0 0
+    position: absolute
+    left: -120px
+
+    ul
+      a
+        text-decoration: none
+
+        &:hover
+          text-decoration: underline
+
+        &:visited
+          text-decoration: none
+
 @media handheld, only screen and (max-width: 767px), only screen and (max-device-width: 767px)
   .fragments
     .content
       // hide image on very small screens
       img#mood
         display: none
+
+    #toc
+      display: none

--- a/content/stylesheets/main.sass
+++ b/content/stylesheets/main.sass
@@ -213,6 +213,7 @@ ol, ul
 
 .list
   a
+    // This style needed by articles list and talks list.
     color: #000
     font-family: $sans_serif
     font-size: 1.55rem

--- a/content/stylesheets/reading.sass
+++ b/content/stylesheets/reading.sass
@@ -14,6 +14,8 @@ $content_width: 680px
 
   .content
     max-width: none
+
+    // Required to show TOC.
     position: relative
 
   #charts

--- a/views/fragments/index.ace
+++ b/views/fragments/index.ace
@@ -3,17 +3,29 @@
   .top-nav
     = include views/_nav
   .top-spacing
-  .content
-    #title
-      h1 Fragments
-    p This section contains a series of short stream of consciousness style notes that don't merit a more dedicated write-up.
-    ul.list
-      {{range .Fragments}}
-        li
-          a href="/fragments/{{.Slug}}"
-            {{.Title}}
-          span.meta
-            |  
-            {{FormatTime .PublishedAt}}
-      {{end}}
+  .fragments
+    .content
+      #title
+        h1 Fragments
+      p.page-intro This section contains a series of short stream of consciousness style notes that don't merit a more dedicated write-up.
+      #toc
+        ul
+          {{range .FragmentsByYear}}
+            li
+              a href="#year-{{.Year}}" {{.Year}}
+          {{end}}
+      #fragments
+        {{range .FragmentsByYear}}
+          div class="year" id="year-{{.Year}}"
+          h2 {{.Year}}
+          ul
+            {{range .Fragments}}
+              li
+                a href="/fragments/{{.Slug}}"
+                  {{.Title}}
+                span.meta
+                  |  
+                  {{FormatTime .PublishedAt}}
+            {{end}}
+        {{end}}
   = include views/_footer


### PR DESCRIPTION
There are now enough fragments that the page is getting pretty
impossible to actually navigate. This breaks the list into years that
are indexed by a TOC and decreases font sizes.