### PR TITLE
Reduce font size of headers in fragments

### DIFF
--- a/content/stylesheets/fragments.sass
+++ b/content/stylesheets/fragments.sass
@@ -3,10 +3,19 @@ $secondary: #cdcdcd
 
 .fragments
   h1
+    font-size: 1.4rem
+    letter-spacing: 0
     hyphens: auto
-    -moz-hyphens: auto
-    -ms-hyphens: auto
-    -webkit-hyphens: auto
+    margin: 20px 0 5px 0
+
+  h2, h3, h4
+    margin: 20px 0 -15px 0
+
+  h2
+    font-size: 1.1em
+
+  h3, h4
+    font-size: 1em
 
   pre
     overflow: initial


### PR DESCRIPTION
Differentiate fragments from articles a bit by reducing the font size of
their headers (and thereby rendering them more distinctive and pop to a
less extreme degree).