### PR TITLE
Add robots.txt if drafts are enabled

### DIFF
--- a/cmd/sorg-build/main.go
+++ b/cmd/sorg-build/main.go
@@ -98,6 +98,9 @@ type Conf struct {
 
 	// Drafts is whether drafts of articles and fragments should be compiled
 	// along with their published versions.
+	//
+	// Activating drafts also prompts the creation of a robots.txt to make sure
+	// that drafts aren't inadvertently accessed by web crawlers.
 	Drafts bool `env:"DRAFTS,default=false"`
 
 	// ContentOnly tells the build step that it should build using only files
@@ -402,6 +405,11 @@ func main() {
 	}
 
 	err = compileReading(db)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = compileRobots(path.Join(conf.TargetDir, "robots.txt"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -754,6 +762,23 @@ func compileReading(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func compileRobots(outPath string) error {
+	if !conf.Drafts {
+		return nil
+	}
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	outFile.WriteString("User-agent: *\n" +
+		"Disallow: /")
 
 	return nil
 }

--- a/cmd/sorg-build/main_test.go
+++ b/cmd/sorg-build/main_test.go
@@ -130,6 +130,26 @@ func TestCompileReading(t *testing.T) {
 	//assert.NoError(t, err)
 }
 
+func TestCompileRobots(t *testing.T) {
+	dir, err := ioutil.TempDir("", "target")
+	assert.NoError(t, err)
+	path := path.Join(dir, "robots.txt")
+
+	conf.Drafts = false
+	err = compileRobots(path)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+
+	conf.Drafts = true
+	err = compileRobots(path)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+}
+
 func TestCompileRuns(t *testing.T) {
 	//
 	// No database


### PR DESCRIPTION
Produce a `robots.txt` file if drafts are enabled so that crawlers don't
accidentally index them.