### PR TITLE
Fix usage of first-letter in Firefox

### DIFF
--- a/content/stylesheets/signature.sass
+++ b/content/stylesheets/signature.sass
@@ -3,7 +3,7 @@
     max-width: 550px
 
     p
-      &:first-letter
+      &:first-of-type:first-letter
         float: left
         font-size: 6.25rem
         line-height: 0.7em

--- a/content/stylesheets/signature.sass
+++ b/content/stylesheets/signature.sass
@@ -2,11 +2,12 @@
   article
     max-width: 550px
 
-    &:first-letter
-      float: left
-      font-size: 6.25rem
-      line-height: 0.7em
-      margin: 5px 10px 0 0
+    p
+      &:first-letter
+        float: left
+        font-size: 6.25rem
+        line-height: 0.7em
+        margin: 5px 10px 0 0
 
 // uncomment the below for multi-column "big" layout
 


### PR DESCRIPTION
Firefox doesn't seem to like first-letter when applied to an article
element, so apply it to paragraphs instead.