### PR TITLE
Publish "The Cost of Manga"

### DIFF
--- a/content/fragments/the-cost-of-manga.md
+++ b/content/fragments/the-cost-of-manga.md
@@ -1,0 +1,41 @@
+---
+title: The Cost of Manga
+published_at: 2016-08-08T16:17:09Z
+hook: "At retail prices, catching up on One Piece would cost $8,200, and Fairy Tail $5,500. Why aren't there legitimate and affordable ways of getting started with these series?"
+---
+
+I recently caught up on the manga super series [One Piece][one-piece] which has
+reached an extraordinary 82 volumes in length, each of which averages around
+200 pages (for a total of ~16,000). While waiting for more of it to be released
+I (perhaps unwisely) starting reading [Fairy Tail][fairy-tail], a series of
+similarly astounding proportions at 55 volumes (~11,000 pages).
+
+After a visit yesterday to Kinokuniya, San Francisco's Japanese bookstore and
+looking at the prices on manga volumes, it got me to thinking how much it would
+actually cost to read one of these series back to front. At an average of $10 a
+volume, One Piece would cost $8,200 to read, and Fairly Tail $5,500. Prices
+will vary depeding on where you source the books from; they'll be more
+expensive at real-world stores ($11), and may be discounted on Amazon ($5 for
+more recent One Piece volumes), but they're roughly right.
+
+Especially given that the series are aimed at younger readers without a lot of
+money, these numbers strike me as _big_. There's probably some expectation that
+some volumes will be swapped with friends or available at a local library, but
+even so getting caught up could be expensive. I don't consider the prices
+extreme either; between the artwork and interesting writing, there's easily $10
+worth of effort wrapped up in one of them.
+
+Realistically, there's a considerable amount of piracy involved in getting
+people on-boarded into either series because there aren't any cost-effective
+legitimate solutions. The digital medium _should_ offer publishers a way to
+solve this problem; perhaps by selling back issues at a fraction of the normal
+price, while the last ten volumes or so stay at $10. Publishers have a natural
+aversion to cheapening their content, even if it's old and has entered the long
+tail its sales curve, but Steam's sales of 50-90% off (and with a proportional
+boost in sales) serves as a guiding light for anyone willing to look for one.
+
+For now, I'm lucky enough to have a library that carries complete collections,
+but if I wasn't, I doubt I'd be reading manga at all.
+
+[fairy-tail]: https://en.wikipedia.org/wiki/Fairy_Tail
+[one-piece]: https://en.wikipedia.org/wiki/One_Piece


### PR DESCRIPTION
At retail prices, catching up on One Piece would cost $8,200, and Fairy
Tail $5,500. Why aren't there legitimate and affordable ways of getting
started with these series?