### PR TITLE
Link to retina assets

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -2,6 +2,7 @@ package markdown
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -86,12 +87,18 @@ func transformFigures(source string) string {
 		matches := figureRE.FindStringSubmatch(figure)
 		src := matches[1]
 
+		link := src
+		extension := filepath.Ext(link)
+		if extension != "" && extension != ".svg" {
+			link = link[0:len(src)-len(extension)] + "@2x" + extension
+		}
+
 		// This is a really ugly hack in that it relies on the regex above
 		// being greedy about quotes, but meh, I'll make it better when there's
 		// a good reason to.
 		caption := strings.Replace(matches[2], `\"`, `"`, -1)
 
-		return fmt.Sprintf(figureHTML, src, src, caption)
+		return fmt.Sprintf(figureHTML, link, src, caption)
 	})
 }
 

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -38,6 +38,26 @@ func TestTransformFigures(t *testing.T) {
 		transformFigures(`!fig src="fig-src" caption="fig-caption"`),
 	)
 
+	// .png links to "@2x" version of the source
+	assert.Equal(t, `
+<figure>
+  <p><a href="fig-src@2x.png"><img src="fig-src.png"></a></p>
+  <figcaption>fig-caption</figcaption>
+</figure>
+`,
+		transformFigures(`!fig src="fig-src.png" caption="fig-caption"`),
+	)
+
+	// .svg doesn't link to "@2x"
+	assert.Equal(t, `
+<figure>
+  <p><a href="fig-src.svg"><img src="fig-src.svg"></a></p>
+  <figcaption>fig-caption</figcaption>
+</figure>
+`,
+		transformFigures(`!fig src="fig-src.svg" caption="fig-caption"`),
+	)
+
 	assert.Equal(t, `
 <figure>
   <p><a href="fig-src"><img src="fig-src"></a></p>


### PR DESCRIPTION
When linking to an in-line figure, always link to the retina version
given that it's more useful.