### PR TITLE
Output multiple errors from a task queue run

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -7,8 +7,11 @@ import (
 
 // Task encapsulates a work item that should go in the pool.
 type Task struct {
-	err error
-	f   func() error
+	// Err holds an error that occurred during a task. Its result is only
+	// meaningful after Run has been called for the pool that holds it.
+	Err error
+
+	f func() error
 }
 
 // NewTask initializes a new Task based on a given work function.
@@ -18,15 +21,16 @@ func NewTask(f func() error) *Task {
 
 // Run runs a Task and does appropriate accounting via a given sync.WorkGroup.
 func (t *Task) Run(wg *sync.WaitGroup) {
-	t.err = t.f()
+	t.Err = t.f()
 	wg.Done()
 }
 
 // Pool is a worker group that runs a number of Task instances at a configured
 // concurrency.
 type Pool struct {
+	Tasks []*Task
+
 	concurrency int
-	tasks       []*Task
 	tasksChan   chan *Task
 	wg          *sync.WaitGroup
 }
@@ -35,39 +39,42 @@ type Pool struct {
 // concurrency.
 func NewPool(tasks []*Task, concurrency int) *Pool {
 	return &Pool{
+		Tasks:       tasks,
 		concurrency: concurrency,
-		tasks:       tasks,
 		tasksChan:   make(chan *Task),
 		wg:          new(sync.WaitGroup),
 	}
 }
 
+// HasErrors indicates whether there were any errors from tasks run. Its result
+// is only meaningful after Run has been called.
+func (p *Pool) HasErrors() bool {
+	for _, task := range p.Tasks {
+		if task.Err != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // Run runs all work within the Pool. The first error that's detected after all
 // work is done is returned.
-func (p *Pool) Run() error {
+func (p *Pool) Run() {
 	log.Debugf("Running %v task(s) at concurrency %v.",
-		len(p.tasks), p.concurrency)
+		len(p.Tasks), p.concurrency)
 
 	for i := 0; i < p.concurrency; i++ {
 		go p.work()
 	}
 
-	p.wg.Add(len(p.tasks))
-	for _, task := range p.tasks {
+	p.wg.Add(len(p.Tasks))
+	for _, task := range p.Tasks {
 		p.tasksChan <- task
 	}
 	p.wg.Wait()
 
 	// all workers return
 	close(p.tasksChan)
-
-	for _, task := range p.tasks {
-		if task.err != nil {
-			return task.err
-		}
-	}
-
-	return nil
 }
 
 func (p *Pool) work() {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -9,8 +9,10 @@ import (
 
 func TestEmptyPool(t *testing.T) {
 	p := NewPool(nil, 10)
-	err := p.Run()
-	assert.NoError(t, err)
+	p.Run()
+
+	assert.Equal(t, []error(nil), poolErrors(p))
+	assert.Equal(t, false, p.HasErrors())
 }
 
 func TestWithWork(t *testing.T) {
@@ -20,8 +22,10 @@ func TestWithWork(t *testing.T) {
 		NewTask(func() error { return nil }),
 	}
 	p := NewPool(tasks, 10)
-	err := p.Run()
-	assert.NoError(t, err)
+	p.Run()
+
+	assert.Equal(t, []error(nil), poolErrors(p))
+	assert.Equal(t, false, p.HasErrors())
 }
 
 func TestWithError(t *testing.T) {
@@ -31,6 +35,19 @@ func TestWithError(t *testing.T) {
 		NewTask(func() error { return fmt.Errorf("error") }),
 	}
 	p := NewPool(tasks, 10)
-	err := p.Run()
-	assert.Equal(t, fmt.Errorf("error"), err)
+	p.Run()
+
+	assert.Equal(t, []error{fmt.Errorf("error")}, poolErrors(p))
+	assert.Equal(t, true, p.HasErrors())
+}
+
+// Gets a list of errors from a pool.
+func poolErrors(p *Pool) []error {
+	var errs []error
+	for _, task := range p.Tasks {
+		if task.Err != nil {
+			errs = append(errs, task.Err)
+		}
+	}
+	return errs
 }


### PR DESCRIPTION
If multiple errors occurred while running a task queue, print up to 10
of them. In the same style as the Go compiler, print "too many errors"
if more than that occurred.