### PR TITLE
Use hooks instead of word counts for fragments listing

### DIFF
--- a/cmd/sorg-build/main.go
+++ b/cmd/sorg-build/main.go
@@ -151,6 +151,9 @@ type Fragment struct {
 	// Draft indicates that the fragment is not yet published.
 	Draft bool `yaml:"-"`
 
+	// Hook is a leading sentence or two to succinctly introduce the fragment.
+	Hook string `yaml:"hook"`
+
 	// Image is an optional image that may be included with a fragment.
 	Image string `yaml:"image"`
 

--- a/templatehelpers/helpers.go
+++ b/templatehelpers/helpers.go
@@ -30,7 +30,6 @@ var FuncMap = template.FuncMap{
 	"RenderTweetContent":           renderTweetContent,
 	"RoundToString":                roundToString,
 	"ToStars":                      toStars,
-	"WordCount":                    wordCount,
 }
 
 func distanceOfTimeInWords(to, from time.Time) string {
@@ -207,16 +206,4 @@ func toStars(n int) string {
 		stars += "★ "
 	}
 	return stars
-}
-
-// wordCount gives an approximate number of words in an article. Newlines and
-// other things will probably mess it up, so it's not reliable.
-func wordCount(s string) int {
-	if s == "" {
-		return 0
-	}
-
-	// Add one because we're actually just counting spaces between words and so
-	// have N + 1 objects.
-	return strings.Count(s, " ") + 1
 }

--- a/templatehelpers/helpers_test.go
+++ b/templatehelpers/helpers_test.go
@@ -152,11 +152,6 @@ func TestToStars(t *testing.T) {
 	assert.Equal(t, "★ ★ ★ ★ ★ ", toStars(5))
 }
 
-func TestWordCount(t *testing.T) {
-	assert.Equal(t, 0, wordCount(""))
-	assert.Equal(t, 5, wordCount("hello there, my name is"))
-}
-
 func mustParseDuration(s string) time.Duration {
 	d, err := time.ParseDuration(s)
 	if err != nil {

--- a/views/index.ace
+++ b/views/index.ace
@@ -28,7 +28,7 @@
             li
               a href="/fragments/{{.Slug}}" {{.Title}}
               p
-                | {{WordCount .Content}} words. 
+                | {{HTML .Hook}} 
                 span.meta {{FormatTime .PublishedAt}}
           {{end}}
         p.older


### PR DESCRIPTION
On the home page, show hooks instead of word counts when listing
fragments. This is a little more effort, but the old word counts weren't
useful and also didn't look good.