### PR TITLE
Require hooks for articles on fragments

### DIFF
--- a/cmd/sorg-build/main.go
+++ b/cmd/sorg-build/main.go
@@ -553,6 +553,10 @@ func compileArticle(dir, name string, draft bool) (*Article, error) {
 		return nil, fmt.Errorf("No publish date for article: %v", inPath)
 	}
 
+	if article.Hook == "" {
+		return nil, fmt.Errorf("No hook for article: %v", inPath)
+	}
+
 	article.Content = markdown.Render(content)
 
 	article.TOC, err = toc.Render(article.Content)
@@ -670,6 +674,10 @@ func compileFragment(dir, name string, draft bool) (*Fragment, error) {
 
 	if fragment.PublishedAt == nil {
 		return nil, fmt.Errorf("No publish date for fragment: %v", inPath)
+	}
+
+	if fragment.Hook == "" {
+		return nil, fmt.Errorf("No hook for fragment: %v", inPath)
 	}
 
 	fragment.Content = markdown.Render(content)

--- a/content/drafts/api-versioning.md
+++ b/content/drafts/api-versioning.md
@@ -2,6 +2,7 @@
 hook: ''
 published_at: 2013-09-01T15:59:44Z
 title: API Versioning
+hook: Best practices for implementing an API versioning scheme.
 ---
 
 ## Web API Versioning Schemes

--- a/content/fragments-drafts/bergen.md
+++ b/content/fragments-drafts/bergen.md
@@ -2,6 +2,7 @@
 title: Bergen
 published_at: 2016-06-07T16:45:37Z
 image: https://c2.staticflickr.com/2/1469/26776970985_7eaccd3e31_b.jpg
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Ever since he moved to Norway about five years ago, I've been promising to

--- a/content/fragments-drafts/implicit-behavior.md
+++ b/content/fragments-drafts/implicit-behavior.md
@@ -1,6 +1,7 @@
 ---
 title: Implicit Behavior
 published_at: 2016-08-04T19:37:47Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 ``` ruby

--- a/content/fragments-drafts/red-and-use.md
+++ b/content/fragments-drafts/red-and-use.md
@@ -1,6 +1,7 @@
 ---
 title: RED & USE
 published_at: 2016-07-15T15:20:51Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 > If it’s a resource, like a queue, instrument it according to Brendan Gregg’s

--- a/content/fragments/2015-resolutions.md
+++ b/content/fragments/2015-resolutions.md
@@ -1,6 +1,7 @@
 ---
 title: 2015 Resolutions
 published_at: 2015-01-03T23:27:49Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Five basic resolutions for 2015:

--- a/content/fragments/2015-update.md
+++ b/content/fragments/2015-update.md
@@ -1,6 +1,7 @@
 ---
 title: 2015 Resolutions (Update)
 published_at: 2015-10-18T19:28:34Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 As we're nearing the end of the year, it's time for a quick revisit to my

--- a/content/fragments/accumulation.md
+++ b/content/fragments/accumulation.md
@@ -1,6 +1,7 @@
 ---
 title: Accumulation
 published_at: 2016-02-23T21:06:03Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I really enjoyed [this article on "stuff"][gifts] from Derek Sivers. Every time

--- a/content/fragments/acm.md
+++ b/content/fragments/acm.md
@@ -1,6 +1,7 @@
 ---
 title: AWS Certificate Manager
 published_at: 2016-01-21T20:47:11Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Yesterday Amazon shipped their best addition to the AWS toolchain in a long

--- a/content/fragments/amazon.md
+++ b/content/fragments/amazon.md
@@ -1,6 +1,7 @@
 ---
 title: The Everything Store
 published_at: 2015-08-09T18:10:56Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 ★ ★ ★ ★ ★ (out of five)

--- a/content/fragments/apkg.md
+++ b/content/fragments/apkg.md
@@ -1,6 +1,7 @@
 ---
 title: Anki's .apkg
 published_at: 2014-10-26T16:40:00Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I was examining Anki today to get a feel for how difficult it would be to

--- a/content/fragments/asturias-checkin.md
+++ b/content/fragments/asturias-checkin.md
@@ -1,6 +1,7 @@
 ---
 title: Asturias Check-in
 published_at: 2016-07-25T15:17:20Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I've been working on Issac Albeniz's guitar masterpiece _Asturias_ for a few

--- a/content/fragments/avast.md
+++ b/content/fragments/avast.md
@@ -1,6 +1,7 @@
 ---
 title: Avast
 published_at: 2016-03-31T18:10:55Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 A user opened an issue on an open-source package that I maintain indicating

--- a/content/fragments/aws-static-hosting-workaround.md
+++ b/content/fragments/aws-static-hosting-workaround.md
@@ -1,6 +1,7 @@
 ---
 title: An AWS Static Hosting Workaround
 published_at: 2016-01-05T17:49:42Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After writing a short article yesterday about [static hosting on AWS][first], a

--- a/content/fragments/aws-static-hosting.md
+++ b/content/fragments/aws-static-hosting.md
@@ -1,6 +1,7 @@
 ---
 title: AWS Static Hosting
 published_at: 2016-01-04T09:18:18Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 **Addendum &mdash;** I've published a [second post][second] containing a

--- a/content/fragments/bicycles.md
+++ b/content/fragments/bicycles.md
@@ -1,6 +1,7 @@
 ---
 title: Bicycles
 published_at: 2014-06-06T07:20:15Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 It's Sausalito on a warm Saturday afternoon. The sun is shining and a stream of

--- a/content/fragments/brevity.md
+++ b/content/fragments/brevity.md
@@ -1,6 +1,7 @@
 ---
 title: On Brevity
 published_at: 2016-04-28T16:22:06Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I start out writing one of these with the idea that it will be two or three

--- a/content/fragments/burn-parties.md
+++ b/content/fragments/burn-parties.md
@@ -1,6 +1,7 @@
 ---
 title: Burn Parties
 published_at: 2016-01-30T04:03:01Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Part of running a product company is shipping new features, but the other often

--- a/content/fragments/calorie-counting.md
+++ b/content/fragments/calorie-counting.md
@@ -1,6 +1,7 @@
 ---
 title: Calorie Counting
 published_at: 2016-06-07T16:06:39Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I'm on a fitness push right now and have started running a small experiment

--- a/content/fragments/cineplex-odeon.md
+++ b/content/fragments/cineplex-odeon.md
@@ -1,6 +1,7 @@
 ---
 title: Cineplex Odeon
 published_at: 2015-12-24T19:11:16Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 During a recent viewing of [_The Force Awakens_][force-awakens] in my hometown

--- a/content/fragments/cloudflare-ssl.md
+++ b/content/fragments/cloudflare-ssl.md
@@ -1,6 +1,7 @@
 ---
 title: CloudFlare Universal SSL
 published_at: 2014-11-12T04:56:26Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I recently activated [CloudFlare's free Universal SSL][cloudflare] for a few of

--- a/content/fragments/cloudfront-indexes.md
+++ b/content/fragments/cloudfront-indexes.md
@@ -1,6 +1,7 @@
 ---
 title: CloudFront Indexes
 published_at: 2016-07-18T16:34:33Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Some of us are vain enough to want to be able to use extensionless filenames

--- a/content/fragments/codeword.md
+++ b/content/fragments/codeword.md
@@ -1,6 +1,7 @@
 ---
 title: Codeword
 published_at: 2016-04-07T08:44:20Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Those of you tuned into San Francisco will already know that last year jwz

--- a/content/fragments/cubano.md
+++ b/content/fragments/cubano.md
@@ -1,6 +1,7 @@
 ---
 title: The Cubano
 published_at: 2014-11-27T05:11:21Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I've recently been working on some cocktails that include egg white and came

--- a/content/fragments/digital-natives.md
+++ b/content/fragments/digital-natives.md
@@ -1,6 +1,7 @@
 ---
 title: Digital Natives
 published_at: 2016-02-23T22:07:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 From an interview with [Douglas Rushkoff][interview] (early Internet culture

--- a/content/fragments/do-debug.md
+++ b/content/fragments/do-debug.md
@@ -1,6 +1,7 @@
 ---
 title: _Do_ Debug
 published_at: 2016-06-23T03:31:58Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 From a random person on [Twitter this morning][dont-debug]:

--- a/content/fragments/entropy.md
+++ b/content/fragments/entropy.md
@@ -1,6 +1,7 @@
 ---
 title: Entropy
 published_at: 2015-09-17T19:52:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 A curious thing that occurs over the course of a job is the accumulation of

--- a/content/fragments/fast-osx-lock.md
+++ b/content/fragments/fast-osx-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Fast OSX Screen Lock
 published_at: 2016-01-22T22:28:01Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The fastest way to lock your screen a modern Mac is to use the key combination

--- a/content/fragments/gh-ost.md
+++ b/content/fragments/gh-ost.md
@@ -1,6 +1,7 @@
 ---
 title: Gh-ost
 published_at: 2016-08-03T07:59:34Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Yesterday, released [Gh-ost][gh-ost], a tool to help makes changes to an online

--- a/content/fragments/go-recover.md
+++ b/content/fragments/go-recover.md
@@ -1,6 +1,7 @@
 ---
 title: Global Recovery in Go With Defer
 published_at: 2014-09-21T17:53:09Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Having spent the last few weeks trying to become literate in Golang, I can

--- a/content/fragments/go-relax.md
+++ b/content/fragments/go-relax.md
@@ -1,6 +1,7 @@
 ---
 title: Go Relax
 published_at: 2014-06-28T20:16:22Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I've been writing a lot of Go code over the last week, and I'm finally coming

--- a/content/fragments/going-static.md
+++ b/content/fragments/going-static.md
@@ -1,6 +1,7 @@
 ---
 title: Going Static
 published_at: 2016-07-14T00:31:55Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 As of yesterday, I completed a rewrite of this site and moved it over from a

--- a/content/fragments/google-domains.md
+++ b/content/fragments/google-domains.md
@@ -1,6 +1,7 @@
 ---
 title: Google Domains
 published_at: 2015-05-17T03:29:55Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I just moved a few of my domains over to [Google's new Domains

--- a/content/fragments/google-engineering-principles.md
+++ b/content/fragments/google-engineering-principles.md
@@ -1,6 +1,7 @@
 ---
 title: Google Engineering Principles
 published_at: 2016-02-03T19:37:54Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Here's a good talk on engineering principles at Google entitled [_Engineering

--- a/content/fragments/gossip-from-across-the-world.md
+++ b/content/fragments/gossip-from-across-the-world.md
@@ -1,6 +1,7 @@
 ---
 title: Gossip From Across the World
 published_at: 2014-05-16T09:39:48Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 You wake up to a massive e-mail backlog like you'd have after a taking a

--- a/content/fragments/got-pessimism.md
+++ b/content/fragments/got-pessimism.md
@@ -1,6 +1,7 @@
 ---
 title: Game of Thrones Pessimism
 published_at: 2016-01-03T00:49:07Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 [George R. R. Martin announced today][announcement] that _The Winds of Winter_

--- a/content/fragments/gpg-curl.md
+++ b/content/fragments/gpg-curl.md
@@ -1,6 +1,7 @@
 ---
 title: GPG + Curl
 published_at: 2014-11-10T20:14:35Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 A very convenient feature of Curl is that if invoked with `curl -n`, it will

--- a/content/fragments/gpg-git.md
+++ b/content/fragments/gpg-git.md
@@ -1,6 +1,7 @@
 ---
 title: GPG + HTTP Git
 published_at: 2014-12-11T21:48:06Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Along with a few other protocols like SSH, Git can communicate with a remote

--- a/content/fragments/gpg-heroku.md
+++ b/content/fragments/gpg-heroku.md
@@ -1,6 +1,7 @@
 ---
 title: GPG + the Heroku CLI
 published_at: 2014-12-11T21:53:11Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Luckily, this one is easy, but I figured I'd put a placeholder here just in

--- a/content/fragments/gpg-s3cmd.md
+++ b/content/fragments/gpg-s3cmd.md
@@ -1,6 +1,7 @@
 ---
 title: GPG + s3cmd
 published_at: 2014-11-10T20:27:47Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 [s3cmd](http://s3tools.org/s3cmd) is a simple tool for use with Amazon's S3 and

--- a/content/fragments/gpg-stripe.md
+++ b/content/fragments/gpg-stripe.md
@@ -1,6 +1,7 @@
 ---
 title: GPG at Stripe
 published_at: 2015-10-18T21:02:24Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 One surprise for me when finally getting a close-up look at Stripe's internal

--- a/content/fragments/guitar.md
+++ b/content/fragments/guitar.md
@@ -1,6 +1,7 @@
 ---
 title: The Guitar
 published_at: 2015-06-14T01:32:26Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The first time I picked up a guitar I was 21 and out in Waterloo for an

--- a/content/fragments/heavy-complexity.md
+++ b/content/fragments/heavy-complexity.md
@@ -1,6 +1,7 @@
 ---
 title: Heavy Complexity
 published_at: 2016-01-25T06:12:05Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The article [_the Sad State of Web Development_][article] may hyperbolic to the

--- a/content/fragments/hm-sportswear.md
+++ b/content/fragments/hm-sportswear.md
@@ -1,6 +1,7 @@
 ---
 title: H&M Sportswear
 published_at: 2016-06-28T15:37:38Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I've been struggling to find a brand of sports shirt that I like for some time

--- a/content/fragments/hype-trains.md
+++ b/content/fragments/hype-trains.md
@@ -1,6 +1,7 @@
 ---
 title: Hype Trains
 published_at: 2016-07-20T14:22:09Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 One thing that the tech industry does well is hype. An idea gets pitched once,

--- a/content/fragments/ibooks.md
+++ b/content/fragments/ibooks.md
@@ -1,6 +1,7 @@
 ---
 title: iBooks & Dropbox
 published_at: 2014-09-21T17:07:10Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After recently starting the grind through David Foster Wallace's 1100 page

--- a/content/fragments/infinite-jest.md
+++ b/content/fragments/infinite-jest.md
@@ -1,6 +1,7 @@
 ---
 title: Infinite Jest
 published_at: 2015-02-05T03:26:42Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 ![Infinite Jest on a table](https://pbs.twimg.com/media/B25yqPsIEAECykQ.jpg:medium)

--- a/content/fragments/insecurity-by-instinct.md
+++ b/content/fragments/insecurity-by-instinct.md
@@ -1,6 +1,7 @@
 ---
 title: Insecurity By Instinct
 published_at: 2015-12-25T01:09:44Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After two years of good luck, I dropped my iPhone 6 on the sidewalk and the

--- a/content/fragments/inventory-ephemeralization.md
+++ b/content/fragments/inventory-ephemeralization.md
@@ -1,6 +1,7 @@
 ---
 title: Inventory Ephemeralization
 published_at: 2015-01-03T22:56:24Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I was just thinking about all the types of items that I would regularly have

--- a/content/fragments/ipad-mini.md
+++ b/content/fragments/ipad-mini.md
@@ -2,6 +2,7 @@
 title: The iPad Mini
 published_at: 2016-06-12T22:26:17Z
 image: /assets/fragments/ipad-mini/vista.jpg
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After almost three years of continuous usage and ownership, it's time for a

--- a/content/fragments/json_schema.md
+++ b/content/fragments/json_schema.md
@@ -1,6 +1,7 @@
 ---
 title: json_ schema
 published_at: 2014-05-24T16:17:45Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After a few primitive attempts at developing some basic [JSON

--- a/content/fragments/kubernetes-glance.md
+++ b/content/fragments/kubernetes-glance.md
@@ -1,6 +1,7 @@
 ---
 title: A Glance at Kubernetes
 published_at: 2016-04-12T04:06:32Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After unintentionally putting it off for years, I recently took a look at

--- a/content/fragments/legacy-projects.md
+++ b/content/fragments/legacy-projects.md
@@ -1,6 +1,7 @@
 ---
 title: Legacy Projects & the Maintainer
 published_at: 2015-08-14T05:27:58Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Code has an incredible ability to survive far beyond the expectations of its

--- a/content/fragments/life-without-mediators.md
+++ b/content/fragments/life-without-mediators.md
@@ -1,6 +1,7 @@
 ---
 title: Life Without Mediators
 published_at: 2016-04-27T16:11:28Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 In a small program, the permissiveness that makes Ruby and other dynamic

--- a/content/fragments/macbook-12-revisited.md
+++ b/content/fragments/macbook-12-revisited.md
@@ -1,6 +1,7 @@
 ---
 title: The 12" MacBook Revisited
 published_at: 2015-06-14T04:33:27Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I recently visited Europe for two weeks, and I used my 12" MacBook for the

--- a/content/fragments/macbook-12.md
+++ b/content/fragments/macbook-12.md
@@ -1,6 +1,7 @@
 ---
 title: Notes on the New 12" MacBook
 published_at: 2015-05-19T13:17:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 After a few weeks of deliberation, I decided to go through with the purchase of

--- a/content/fragments/major-buys.md
+++ b/content/fragments/major-buys.md
@@ -1,6 +1,7 @@
 ---
 title: Major Buys
 published_at: 2014-07-19T20:59:12Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I've been reading [/r/watches](http://www.reddit.com/r/Watches/) for a few

--- a/content/fragments/monkeybrains.md
+++ b/content/fragments/monkeybrains.md
@@ -2,6 +2,7 @@
 title: MonkeyBrains
 published_at: 2016-01-23T01:15:58Z
 image: /assets/fragments/monkeybrains/vista.jpg
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 One "worst part" of living in SOMA is the endless construction. Its latest

--- a/content/fragments/naked-dns.md
+++ b/content/fragments/naked-dns.md
@@ -1,6 +1,7 @@
 ---
 title: Naked DNS
 published_at: 2016-01-31T19:39:33Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 A recent link from HN re-raised the discussion about whether it's a good idea

--- a/content/fragments/new-great-companies.md
+++ b/content/fragments/new-great-companies.md
@@ -1,6 +1,7 @@
 ---
 title: Where Are All the New Great Companies?
 published_at: 2016-07-29T15:32:06Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 While listening to a few talks and panels on developer tools this week, it

--- a/content/fragments/new-york.md
+++ b/content/fragments/new-york.md
@@ -1,6 +1,7 @@
 ---
 title: New York
 published_at: 2014-07-16T06:46:51Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Last week I made my first trip ever to New York. Although mainly a trip for work, I managed to see some local friends and relatives, and took as much opportunity as I could manage to visit the city.

--- a/content/fragments/not-hosted-here.md
+++ b/content/fragments/not-hosted-here.md
@@ -1,6 +1,7 @@
 ---
 title: Not Hosted Here
 published_at: 2016-04-27T15:23:51Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Everyone of course knows of the widspread anti-practice of [_not invented

--- a/content/fragments/notification-hell.md
+++ b/content/fragments/notification-hell.md
@@ -1,6 +1,7 @@
 ---
 title: Notification Hell
 published_at: 2016-01-10T03:18:58Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Recently _The Atlantic_ published an article titled [The Triump of

--- a/content/fragments/one-thing.md
+++ b/content/fragments/one-thing.md
@@ -1,6 +1,7 @@
 ---
 title: Do One Thing and Do It Well?
 published_at: 2016-01-04T08:48:16Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I came across [an old Slashdot interview with Rob Pike][pike-interview] today,

--- a/content/fragments/one-week.md
+++ b/content/fragments/one-week.md
@@ -1,6 +1,7 @@
 ---
 title: One Week of Nutritional Rigor
 published_at: 2016-06-13T16:02:34Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I wrote previously that as an experiment, I'm engaging in a [Calorie

--- a/content/fragments/osx-and-entropy.md
+++ b/content/fragments/osx-and-entropy.md
@@ -1,6 +1,7 @@
 ---
 title: OSX and Entropy
 published_at: 2016-07-31T17:39:44Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Bertrand Serlet stopped by Stripe yesterday to do a fireside-chat style

--- a/content/fragments/paper-books.md
+++ b/content/fragments/paper-books.md
@@ -1,6 +1,7 @@
 ---
 title: Paper Books
 published_at: 2015-02-15T04:23:45Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Sad news this month with the announcement of [the closure of Borderland](http://www.sfexaminer.com/sanfrancisco/borderlands-books-in-sf-announces-closure-cites-minimum-wage-increase/Content?oid=2918723), a local science-fiction and fantasy books and local community landmark. Ownership cited San Francisco's recent vote to increase minimum wage as the reason for closing, a measure voted in last November that will increase minimum wage to $15 by July 2018.

--- a/content/fragments/pax-2016-tickets.md
+++ b/content/fragments/pax-2016-tickets.md
@@ -1,6 +1,7 @@
 ---
 title: PAX 2016 Ticket Royale
 published_at: 2016-06-08T06:55:02Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Some friends and decided that we wanted to get tickets to PAX West [1] this

--- a/content/fragments/pax.md
+++ b/content/fragments/pax.md
@@ -1,6 +1,7 @@
 ---
 title: PAX
 published_at: 2014-09-04T22:59:21Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I just returned from my very first experience at PAX Prime in Seattle. I'm not

--- a/content/fragments/perpetual-cookies.md
+++ b/content/fragments/perpetual-cookies.md
@@ -1,6 +1,7 @@
 ---
 title: Perpetual Cookies
 published_at: 2016-07-31T23:36:34Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 When you pop open and start using Uber's app on your iPhone, you drop a pin,

--- a/content/fragments/plex-ps4.md
+++ b/content/fragments/plex-ps4.md
@@ -1,6 +1,7 @@
 ---
 title: Plex for PS4
 published_at: 2015-12-07T18:33:21Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I recently picked up a PS4 mostly due to a FOMO on certain rich gaming

--- a/content/fragments/redshift-keys.md
+++ b/content/fragments/redshift-keys.md
@@ -1,6 +1,7 @@
 ---
 title: Showing Redshift Distkey & Sortkey
 published_at: 2015-10-26T18:25:13Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 One slightly unfortunate aspect of how Postgres interacts with Redshift is that

--- a/content/fragments/safety-razors.md
+++ b/content/fragments/safety-razors.md
@@ -1,6 +1,7 @@
 ---
 title: Safety Razors
 published_at: 2016-01-10T04:59:20Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The subject of safety razors recently came up with a friend, and I was amazed

--- a/content/fragments/safeway.md
+++ b/content/fragments/safeway.md
@@ -1,6 +1,7 @@
 ---
 title: Safeway Justice
 published_at: 2015-10-18T19:51:33Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 One reality of living in San Francisco is that you get to witness every

--- a/content/fragments/sf-activism.md
+++ b/content/fragments/sf-activism.md
@@ -1,6 +1,7 @@
 ---
 title: SF Housing and Activism
 published_at: 2015-12-30T18:07:41Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 _The Atlantic_ published a great article yesterday on [housing activism in San

--- a/content/fragments/six-weeks.md
+++ b/content/fragments/six-weeks.md
@@ -1,6 +1,7 @@
 ---
 title: Six Weeks
 published_at: 2016-07-18T15:03:47Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Six weeks ago, I [started tracking my energy input and

--- a/content/fragments/spectre.md
+++ b/content/fragments/spectre.md
@@ -1,6 +1,7 @@
 ---
 title: Spectre
 published_at: 2015-11-09T05:29:20Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 _(Caution: major spoilers below.)_

--- a/content/fragments/sprawl-blues.md
+++ b/content/fragments/sprawl-blues.md
@@ -2,6 +2,7 @@
 title: The Sprawl Blues
 published_at: 2016-01-03T22:18:36Z
 image: /assets/fragments/sprawl-blues/vista.jpg
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I happened to come across an article about [life in LA][los-angeles-post]

--- a/content/fragments/square-cash.md
+++ b/content/fragments/square-cash.md
@@ -1,6 +1,7 @@
 ---
 title: Square Cash & E-mail as a Platform
 published_at: 2014-05-10T13:18:19Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I made my first Square Cash transaction yesterday, and was delighted by the

--- a/content/fragments/starbucks-growth.md
+++ b/content/fragments/starbucks-growth.md
@@ -1,6 +1,7 @@
 ---
 title: Starbucks Growth
 published_at: 2015-12-07T17:34:10Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The NYT reports today on the continued prosperity of Starbucks which continues

--- a/content/fragments/swift-day-one.md
+++ b/content/fragments/swift-day-one.md
@@ -1,6 +1,7 @@
 ---
 title: "Swift: Day One"
 published_at: 2014-06-03T09:51:57Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Yesterday during the WWDC keynote Apple announced [Swift][swift], a new

--- a/content/fragments/test-kafka.md
+++ b/content/fragments/test-kafka.md
@@ -1,6 +1,7 @@
 ---
 title: Testing a Kafka Connection
 published_at: 2016-02-10T17:54:12Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 It's occasionally useful to test a Kafka connection; for example in case you

--- a/content/fragments/testing-go-project-root.md
+++ b/content/fragments/testing-go-project-root.md
@@ -1,6 +1,7 @@
 ---
 title: Testing Go Packages From Project Root
 published_at: 2016-07-15T16:37:30Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 By default, running `go test` executes a package's tests with the current

--- a/content/fragments/the-bear.md
+++ b/content/fragments/the-bear.md
@@ -1,6 +1,7 @@
 ---
 title: The Bear
 published_at: 2016-01-30T16:02:10Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 > _Sometimes you eat the bear, and sometimes, well, he eats you._

--- a/content/fragments/the-end-of-the-tour.md
+++ b/content/fragments/the-end-of-the-tour.md
@@ -1,6 +1,7 @@
 ---
 title: The End of the Tour
 published_at: 2015-08-17T04:36:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 ★ ★ ★ ★ (out of five)

--- a/content/fragments/the-force-awakens.md
+++ b/content/fragments/the-force-awakens.md
@@ -1,6 +1,7 @@
 ---
 title: "Star Wars VII: The Force Awakens"
 published_at: 2015-12-21T05:55:14Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 _(Caution: major spoilers below.)_

--- a/content/fragments/three-weeks.md
+++ b/content/fragments/three-weeks.md
@@ -1,6 +1,7 @@
 ---
 title: Week Three
 published_at: 2016-06-27T17:07:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Previously, see [week one](/fragments/one-week) and [week

--- a/content/fragments/timing.md
+++ b/content/fragments/timing.md
@@ -1,6 +1,7 @@
 ---
 title: Timing the Guitar
 published_at: 2016-04-05T02:26:11Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Any guitar teacher will tell you to practice with a metronome. _Always._ Any

--- a/content/fragments/traffic.md
+++ b/content/fragments/traffic.md
@@ -1,6 +1,7 @@
 ---
 title: Traffic
 published_at: 2016-04-19T16:35:03Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I write this after having been almost run over this morning in a crosswalk.

--- a/content/fragments/turning-points.md
+++ b/content/fragments/turning-points.md
@@ -1,6 +1,7 @@
 ---
 title: Turning Points
 published_at: 2016-01-20T08:53:16Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Dating in your 30s is a contact sport. The incentive for both parties lies in

--- a/content/fragments/two-stars.md
+++ b/content/fragments/two-stars.md
@@ -1,6 +1,7 @@
 ---
 title: Two Stars
 published_at: 2014-06-11T15:04:13Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 During a recent trip to Leipzig, I had the distinctive pleasure of eating at a

--- a/content/fragments/two-weeks.md
+++ b/content/fragments/two-weeks.md
@@ -1,6 +1,7 @@
 ---
 title: Week Two
 published_at: 2016-06-20T16:30:25Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I previously wrote about my results after [one week](/fragments/one-week) of

--- a/content/fragments/us-east.md
+++ b/content/fragments/us-east.md
@@ -1,6 +1,7 @@
 ---
 title: us-east-1
 published_at: 2016-07-20T04:48:24Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I have fond memories of operating Heroku in us-east-1. Be it the electrical

--- a/content/fragments/verified-env-vars.md
+++ b/content/fragments/verified-env-vars.md
@@ -1,6 +1,7 @@
 ---
 title: Verified Env Vars
 published_at: 2016-07-29T16:30:17Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 While passing information to command line programs with environment variables

--- a/content/fragments/wgt-2015-brain-dump.md
+++ b/content/fragments/wgt-2015-brain-dump.md
@@ -1,6 +1,7 @@
 ---
 title: WGT 2015 Brain Dump
 published_at: 2015-05-26T08:39:18Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I wrote about [WGT](/fragments/wgt) for the first time last year, and this year

--- a/content/fragments/wgt-2015.md
+++ b/content/fragments/wgt-2015.md
@@ -2,6 +2,7 @@
 title: WGT 2015 Abstract
 published_at: 2015-05-29T13:34:59Z
 image: /assets/fragments/wgt-2015/vista.jpg
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 This year I attended the Wave-Gotik-Treffen in Leipzig for the third time. I

--- a/content/fragments/wgt.md
+++ b/content/fragments/wgt.md
@@ -1,6 +1,7 @@
 ---
 title: WGT
 published_at: 2014-06-29T20:01:27Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 The Wave-Gotik-Treffen is a festival that's been happening in Leipzig, Germany

--- a/content/fragments/whiplash.md
+++ b/content/fragments/whiplash.md
@@ -1,6 +1,7 @@
 ---
 title: Whiplash
 published_at: 2015-08-14T03:50:31Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 _(Caution: major spoilers below.)_

--- a/content/fragments/x-forwarded-proto.md
+++ b/content/fragments/x-forwarded-proto.md
@@ -1,6 +1,7 @@
 ---
 title: X-Forwarded-Proto
 published_at: 2014-05-15T09:37:33Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 We use [rack-ssl](https://github.com/josh/rack-ssl) to redirect users making

--- a/content/fragments/yosemite-linux.md
+++ b/content/fragments/yosemite-linux.md
@@ -1,6 +1,7 @@
 ---
 title: Yosemite & Linux
 published_at: 2014-06-28T20:18:22Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I caught my first in-person glimpse of Apple's new OS "Yosemite" the other day.

--- a/content/fragments/yosemite-progress.md
+++ b/content/fragments/yosemite-progress.md
@@ -1,6 +1,7 @@
 ---
 title: Yosemite & Progress Bars
 published_at: 2014-11-10T16:37:30Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 I recently upgraded my system from Mavericks to Yosemite and ran into a pretty

--- a/content/fragments/zero-sum-treadmill.md
+++ b/content/fragments/zero-sum-treadmill.md
@@ -1,6 +1,7 @@
 ---
 title: The Zero-sum Treadmill
 published_at: 2016-06-15T18:15:50Z
+hook: UNWRITTEN. This should not appear on the front page.
 ---
 
 Sometimes you come across comments online that are Internet gold. [Here's one


### PR DESCRIPTION
The front page looks a little strange unless these are properly
included, so put in a check for them in case one is accidentally
forgotten.