### PR TITLE
Don't specify font-size in pixels

### DIFF
--- a/content/stylesheets/main.sass
+++ b/content/stylesheets/main.sass
@@ -68,7 +68,9 @@ h4
 
 html
   // Root font size. All other sizes with "rem" are relative to this.
-  font-size: 16px
+  //
+  // This corresponds to the default font size of 16px.
+  font-size: 100%
 
 img
   display: block

--- a/sorg.go
+++ b/sorg.go
@@ -11,7 +11,7 @@ import (
 const (
 	// Release is the asset version of the site. Bump when any assets are
 	// updated to blow away any browser caches.
-	Release = "10"
+	Release = "11"
 )
 
 const (


### PR DESCRIPTION
This doesn't play nicely with browser accessibility that allows a user
to specify, for example, 120% of normal font size.

The default browser font size is already 16px, so this doesn't actually
introduce a change.

As per:

http://fvsch.com/code/css-locks/