### PR TITLE
Publish fragment "PAX 2016"

### DIFF
--- a/content/fragments/pax-2016.md
+++ b/content/fragments/pax-2016.md
@@ -1,0 +1,39 @@
+---
+title: PAX 2016
+published_at: 2016-09-13T16:21:19Z
+hook: Better known as line-con. Wherein I revisit the infamous video game expo
+  after two years away.
+---
+
+I attended PAX (Penny Arcade Expo) for the first time [in
+2014](/fragments/pax), and back then tried to be generous in consideration of
+my newness to the event. This year I attended again, and have no such qualms:
+PAX is a mediocre convention that is as oversubscribed and is it oversold. The
+lines were worse than ever before; there isn't a single booth, panel, or event
+that you won't be lining up for.
+
+The most popular items like the live session of Acquisitions Incorporated will
+necessitate a commitment of 3+ hours of standing in line. More elaborate
+publisher-driven events like BioWare's "escape from the room" style challenge
+are also 3+ hours. Bethesda's Dishonored 2 Sunday night after party at
+Seattle's "Center for Wooden Boats" had a line up around the block of hopefuls
+praying to get in, many of whom probably never saw the inside of the building.
+Pokemon fans waited over an hour long for the privilege to pay for overpriced
+plushes with an official tag. Standard booths with a few demo consoles often
+had to cap their line after it had encircled their entire installation. And
+forget about attending an even reasonably popular panel unless you got there an
+hour before its listed start time.
+
+A pretty standard strategy for most attendees seemed to be to choose a single
+event for the day and get up early to get in line for it. A normal itinerary
+would then shake out as follows: mornings spent in line nursing a Starbucks
+coffee, 1-2 hours around the early afternoon in the event itself, and then
+spending the afternoon on the expo floor itself, searching for "swag" that
+amounted to branded pens and key rings, and opportunistically looking for any
+demo lines that looked to be less than an hour long.
+
+Between ticket price multiplied by hugely oversold quantities, and what
+publishers are paying to be there, Penny Arcade must be making a _killing_ off
+of PAX. And beside that, you have to appreciate their acumen even more given
+that these same downtrodden fans who spent the majority of their weekend in
+line, love the abuse.


### PR DESCRIPTION
Better known as line-con. Wherein I revisit the infamous video game expo
after two years away.