### PR TITLE
Separate ★s with non-breaking spaces

### DIFF
--- a/templatehelpers/helpers.go
+++ b/templatehelpers/helpers.go
@@ -203,7 +203,7 @@ func roundToString(f float64) string {
 func toStars(n int) string {
 	var stars string
 	for i := 0; i < n; i++ {
-		stars += "★ "
+		stars += "★ "
 	}
 	return stars
 }

--- a/templatehelpers/helpers_test.go
+++ b/templatehelpers/helpers_test.go
@@ -148,8 +148,8 @@ func TestRoundToString(t *testing.T) {
 
 func TestToStars(t *testing.T) {
 	assert.Equal(t, "", toStars(0))
-	assert.Equal(t, "★ ", toStars(1))
-	assert.Equal(t, "★ ★ ★ ★ ★ ", toStars(5))
+	assert.Equal(t, "★ ", toStars(1))
+	assert.Equal(t, "★ ★ ★ ★ ★ ", toStars(5))
 }
 
 func mustParseDuration(s string) time.Duration {


### PR DESCRIPTION
On narrow displays, the browser sometimes inserts line-breaks between the stars of the star-ratings on the [Reading](https://brandur.org/reading) page:
![broken-stars](https://cloud.githubusercontent.com/assets/3820879/18567222/1fea9bbe-7b65-11e6-842d-d8c6a5b395b5.png)
At first glance, very well reviewed books may appear to have been received abysmally. This commit separates the stars using [non-breaking spaces](http://www.fileformat.info/info/unicode/char/00a0/index.htm), instead of [normal spaces](http://www.fileformat.info/info/unicode/char/0020/index.htm). 