### PR TITLE
Add text summary to runs page

### DIFF
--- a/views/runs/index.ace
+++ b/views/runs/index.ace
@@ -7,6 +7,9 @@
     .content
       #title
         h1 Runs
+      {{if .ByYearXYears}}
+        p {{index .ByYearYDistances 0 | RoundToString}} km run in {{index .ByYearXYears 0}}.
+      {{end}}
       #data-distance-last-year.chart
       #data-distance-by-year.chart
       .runs-content


### PR DESCRIPTION
Just adds a simple text summary at the top that looks like:

> 1522.0 km run in 2015.