### PR TITLE
Hide left TOCs on index pages sooner

### DIFF
--- a/content/stylesheets/articles.sass
+++ b/content/stylesheets/articles.sass
@@ -50,24 +50,3 @@ $secondary: #cdcdcd
 
         .title
           line-height: 1.2em
-
-  #toc
-    margin: 0 30px 0 0
-    position: absolute
-    left: -120px
-    width: 80px
-
-    ul
-      a
-        text-decoration: none
-
-        &:hover
-          text-decoration: underline
-
-        &:visited
-          text-decoration: none
-
-@media handheld, only screen and (max-width: 767px), only screen and (max-device-width: 767px)
-  .articles
-    #toc
-      display: none

--- a/content/stylesheets/fragments.sass
+++ b/content/stylesheets/fragments.sass
@@ -85,28 +85,9 @@ $secondary: #cdcdcd
           font-size: 0.75rem
           font-style: italic
 
-  #toc
-    margin: 0 30px 0 0
-    position: absolute
-    left: -120px
-    width: 80px
-
-    ul
-      a
-        text-decoration: none
-
-        &:hover
-          text-decoration: underline
-
-        &:visited
-          text-decoration: none
-
 @media handheld, only screen and (max-width: 767px), only screen and (max-device-width: 767px)
   .fragments
     .content
       // hide image on very small screens
       img#mood
         display: none
-
-    #toc
-      display: none

--- a/content/stylesheets/main.sass
+++ b/content/stylesheets/main.sass
@@ -274,7 +274,7 @@ ol, ul
       color: #fff
       text-shadow: 0 0 2px #000
 
-#toc
+.toc
   float: right
   font-family: $sans_serif
   font-size: 0.8rem
@@ -311,6 +311,45 @@ ol, ul
 
           ol
             list-style-type: none
+
+// This is a TOC that shows up on the left side of the screen for the
+// fragments, reading, twitter, etc. index pages.
+.toc-index
+  margin: 0 30px 0 0
+  position: absolute
+  left: -120px
+  width: 80px
+
+  ul
+    a
+      text-decoration: none
+
+      &:hover
+        text-decoration: underline
+
+      &:visited
+        text-decoration: none
+
+    // Sublists. Currently only used for months under years of Twitter.
+    ul
+      margin: 10px
+
+      li
+        color: $secondary
+        font-family: $sans_serif
+        font-size: 0.75rem
+        //line-height: 1.5em
+
+        a
+          color: $secondary
+          text-decoration: none
+
+          &:hover
+            color: $secondary
+            text-decoration: underline
+
+          &:visited
+            color: $secondary
 
 #footnotes
   border-top: 1px solid $tertiary
@@ -375,6 +414,13 @@ footer
     border-top: 1px solid $tertiary
     padding: 25px 20px
     text-align: center
+
+// The index TOC floats a little out to the left which requires a slightly
+// larger screen to look good. Hide it earlier than we usually react to native
+// layouts for.
+@media handheld, only screen and (max-width: 1000px), only screen and (max-device-width: 1000px)
+  .toc-index
+    display: none
 
 @media handheld, only screen and (max-width: 767px), only screen and (max-device-width: 767px)
   .hook

--- a/content/stylesheets/reading.sass
+++ b/content/stylesheets/reading.sass
@@ -26,22 +26,6 @@ $content_width: 680px
     height: 240px
     width: 49%
 
-  #toc
-    margin: 0 30px 0 0
-    position: absolute
-    left: -120px
-    width: 80px
-
-    ul
-      a
-        text-decoration: none
-
-        &:hover
-          text-decoration: underline
-
-        &:visited
-          text-decoration: none
-
   #books
     max-width: $content_width
 
@@ -60,9 +44,6 @@ $content_width: 680px
       float: none
       margin: 0
       width: 100%
-
-    #toc
-      display: none
 
 @media only screen and (min-width: 1800px)
   .reading

--- a/content/stylesheets/twitter.sass
+++ b/content/stylesheets/twitter.sass
@@ -19,42 +19,6 @@ $content_width: 680px
   #data-tweets-by-month
     height: 300px
 
-  #toc
-    margin: 0 30px 0 0
-    position: absolute
-    left: -120px
-    width: 80px
-
-    ul
-      a
-        text-decoration: none
-
-      a:hover
-        text-decoration: underline
-
-      a:visited
-        text-decoration: none
-
-      ul
-        margin: 10px
-
-        li
-          color: $secondary
-          font-family: $sans_serif
-          font-size: 0.75rem
-          //line-height: 1.5em
-
-          a
-            color: $secondary
-            text-decoration: none
-
-            &:hover
-              color: $secondary
-              text-decoration: underline
-
-            &:visited
-              color: $secondary
-
   .twitter-content
     max-width: $content_width
 
@@ -80,11 +44,6 @@ $content_width: 680px
 
               &:visited
                 color: $secondary
-
-@media handheld, only screen and (max-width: 767px), only screen and (max-device-width: 767px)
-  .twitter
-    #toc
-      display: none
 
 @media only screen and (min-width: 1800px)
   .twitter

--- a/sorg.go
+++ b/sorg.go
@@ -11,7 +11,7 @@ import (
 const (
 	// Release is the asset version of the site. Bump when any assets are
 	// updated to blow away any browser caches.
-	Release = "14"
+	Release = "15"
 )
 
 const (

--- a/views/articles/index.ace
+++ b/views/articles/index.ace
@@ -7,7 +7,7 @@
     .content
       #title
         h1 Articles
-      #toc
+      .toc.toc-index
         ul
           {{range .ArticlesByYear}}
             li

--- a/views/articles/show.ace
+++ b/views/articles/show.ace
@@ -22,7 +22,7 @@
         p.hook {{.Article.Hook}}
         .divider-short
       {{end}}
-      #toc
+      .toc
         {{if ne .Article.TOC ""}}
           h2 Table of Contents
           {{HTML .Article.TOC}}

--- a/views/fragments/index.ace
+++ b/views/fragments/index.ace
@@ -8,7 +8,7 @@
       #title
         h1 Fragments
       p.page-intro This section contains a series of short stream of consciousness style notes that don't merit a more dedicated write-up.
-      #toc
+      .toc.toc-index
         ul
           {{range .FragmentsByYear}}
             li

--- a/views/reading/index.ace
+++ b/views/reading/index.ace
@@ -12,7 +12,7 @@
         #data-readings-by-year.chart
         #data-pages-by-year.chart
         .clear
-      #toc
+      .toc.toc-index
         ul
           {{range .ReadingsByYear}}
             li

--- a/views/twitter/index.ace
+++ b/views/twitter/index.ace
@@ -14,7 +14,7 @@
           p <a href="/twitter">{{NumberWithDelimiter ',' .NumTweets}} tweets</a>, and {{NumberWithDelimiter ',' .NumTweetsWithReplies}} including replies.
         {{end}}
       #data-tweets-by-month.chart
-      #toc
+      .toc.toc-index
         ul
           {{range $year := .TweetsByYearAndMonth}}
             li


### PR DESCRIPTION
Hides the table of contents on the left side of index pages (e.g.
fragments, reading) earlier so that it doesn't float off the page as a
window gets smaller.

Also take the opportunity to consolidate all the separate TOC stylings
into a single rule in main.