### PR TITLE
Publish "Fixing a Slow Git $PS1 Prompt"

### DIFF
--- a/content/fragments/hide-dirty.md
+++ b/content/fragments/hide-dirty.md
@@ -1,0 +1,36 @@
+---
+title: Fixing a Slow Git $PS1 Prompt
+published_at: 2016-11-17T04:42:17Z
+hook: A simple trick to measurably improve prompt performance in a large Git
+  repository.
+---
+
+Like many other developers, I've configured my prompt's `$PS1` to display my
+current branch in Git:
+
+    st-brandur1 my-project(master*) $
+
+This is accomplishing by invoking Oh-My-Zsh's `git_prompt_info` function. Bash
+has a similar mechanism called `__git_ps1`.
+
+This worked great for me for years until I started working in repositories with
+very large Git histories. For example, the kernel tree, Rust, or Servo will all
+demonstrate the effect. `git_prompt_info` took so long to return that the
+latency was disruptive when typing commands in quick succession.
+
+`git_prompt_info` calls into `git status`. Along with getting the current
+branch name, it returns another piece of information -- whether the repository
+is "dirty" in that it has uncommitted changes. In the prompt line above, that
+manifests as the `*` shown after the branch name. This dirty check is very slow
+and was single-handedly responsible for my unresponsive prompt.
+
+Luckily, Oh-My-Zsh is good enough to include an option to skip the dirty check.
+It's set as part of Git configuration:
+
+    $ git config --add oh-my-zsh.hide-dirty 1
+
+Bash includes something very similar:
+
+    $ git config bash.showDirtyState false
+
+My problems with a slow prompt evaporated instantly.


### PR DESCRIPTION
A simple trick to measurably improve prompt performance in a large Git
repository.