### PR TITLE
Add script to check for headers without IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-all: clean install test vet lint check-gofmt check-retina build
+all: clean install test vet lint check-gofmt check-headers check-retina build
 
 build:
 	$(GOPATH)/bin/sorg-build
 
 check-gofmt:
 	scripts/check_gofmt.sh
+
+check-headers:
+	scripts/check_headers.sh
 
 check-retina:
 	scripts/check_retina.sh

--- a/content/articles/alerting.md
+++ b/content/articles/alerting.md
@@ -156,8 +156,7 @@ somebody will receive eventually (like an e-mail), but which won't page outside
 of business hours. One those warning-style alerts are vetted and stable,
 promote them to production.
 
-### Don't Allow Flappy Alarms to Enter the Shared Consciousness
-(#flappy-alarms)
+### Don't Allow Flappy Alarms to Enter the Shared Consciousness (#flappy-alarms)
 
 As busy engineers, one bad habit that we're particularly susceptible to is
 applying the fastest possible fix to a problem and moving on without

--- a/content/articles/canonical-log-lines.md
+++ b/content/articles/canonical-log-lines.md
@@ -113,9 +113,9 @@ We import data by emitting lines over a fast queueing system (NSQ), archiving
 batches of it to S3, and then periodically running a `COPY` pointing to the
 bucket from Redshift.
 
-## Examples
+## Examples (#examples)
 
-### Example: HTTP 500s By Breakage
+### Example: HTTP 500s By Breakage (#500s-by-breakage)
 
 One of the hazards of any software stack is that unexpected breakages will
 happen. For a typical web service, this often takes the form of an exception
@@ -146,7 +146,7 @@ are counts of timeout errors over the last week by API version:
 
 > [search breakage-splunkline error_class=Chalk::ODM::OperationTimeout sourcetype=bapi-srv earliest=-7d | fields action_id] canonical-api-line | stats count by stripe_version | sort -count limit 10
 
-### Example: TLS Deprecation
+### Example: TLS Deprecation (#tls-deprecation)
 
 One project that I'm working on right now is helping Stripe users [migrate to
 TLS 1.2 from older secure protocols][upgrading-tls]. TLS 1.2 will eventually be
@@ -251,7 +251,7 @@ App = Rack::Builder.new do
 end
 ```
 
-## Summary
+## Summary (#summary)
 
 By now I've hopefully convinced you that canonical log lines provide a pretty
 useful "middle tier" of operational visibility into a production stack. They're

--- a/content/articles/free-certificates.md
+++ b/content/articles/free-certificates.md
@@ -31,9 +31,9 @@ personal websites, and everything in between. Hopefully by reading this guide,
 you'll realize that there aren't any excuses for running an insecure website
 anymore, so come on, let's encrypt!
 
-## Services
+## Services (#services)
 
-### CloudFlare
+### CloudFlare (#cloudflare)
 
 **Website:** [https://www.cloudflare.com/][cloudflare]
 
@@ -72,7 +72,7 @@ for browsing. As of today, ["Can I Use ...?" estimates support at 97+%
 globally][caniuse], so an SNI-based solution is probably appropriate for you as
 long as you're running an operation that's smaller than Google.
 
-### Let's Encrypt
+### Let's Encrypt (#lets-encrypt)
 
 **Website:** [https://letsencrypt.org/][lets-encrypt]
 
@@ -104,7 +104,7 @@ The bad:
   that allows for easy automation goes a long way towards compensating for
   this.
 
-### AWS Certificate Manager
+### AWS Certificate Manager (#acm)
 
 **Website:** [https://aws.amazon.com/certificate-manager/][acm]
 
@@ -133,7 +133,7 @@ The bad:
   if you're on Amazon, there'a a pretty good chance that you're _all_ on
   Amazon, and this won't be a huge problem.
 
-### StartSSL
+### StartSSL (#startssl)
 
 **Website:** [https://www.startssl.com/][startssl]
 
@@ -162,7 +162,7 @@ The ugly:
   users will be able to understand what's going on here and get a certificate
   issued safely.
 
-## Summary
+## Summary (#summary)
 
 There's a lot of information above, so here's a simple heuristic that should do
 the trick for most people:

--- a/content/articles/go-worker-pool.md
+++ b/content/articles/go-worker-pool.md
@@ -84,7 +84,7 @@ So if primitives alone already present such an elegant solution, why would
 anyone ever argue for introducing another unneeded layer of abstraction and
 complexity?
 
-## Error Handling
+## Error Handling (#error-handling)
 
 Well, there's a simplification in the above example that you may have spotted
 already. While it's perfectly fine if the workload for our asynchronous tasks
@@ -167,7 +167,7 @@ func main() {
 
 As you can see, it's fine code, but not quite as elegant as the original.
 
-### Potential Fragility
+### Potential Fragility (#fragility)
 
 In our example above, we've accidentally introduced a fairly insidious problem
 in that if our error channel is smaller than the number of work items that will
@@ -198,7 +198,7 @@ It's quite possible to address that problem as well, but it helps to show that
 developing a useful and bug-free worker pool in Go isn't quite as simple as
 it's often made out to be.
 
-## Implementing A Robust Worker Pool
+## Implementing A Robust Worker Pool (#implementing)
 
 Putting together a good worker pool abstraction is pretty simple, and can even
 be done reliably with a minimal amount of code. Here's the worker pool
@@ -310,7 +310,7 @@ for _, task := range p.Tasks {
 }
 ```
 
-## Summary
+## Summary (#summary)
 
 Even though putting together a robust worker pool isn't overly problematic,
 right now it's something that every project needs to handle on its own. The

--- a/content/articles/logfmt.md
+++ b/content/articles/logfmt.md
@@ -116,7 +116,7 @@ The value becomes even more apparent when we consider what would be logged on an
       error_message="undefined method `serialize' for nil:NilClass"
       user=brandur@mutelight.org user_id=1234 app=mutelight app_id=1234
 
-## Implementations
+## Implementations (#implementations)
 
 A few projects from already exist to help parse logfmt in various languages:
 

--- a/content/articles/psql-objects.md
+++ b/content/articles/psql-objects.md
@@ -30,7 +30,7 @@ Between complex nesting and name collisions, using Postgres tools to navigate
 unfamiliar arrangements of these objects can be a little tricky. Luckily `psql`
 exposes some handy shortcuts for working with them.
 
-## Databases
+## Databases (#databases)
 
 We can use `\list` (`\l`) to list all the databases in a cluster:
 
@@ -40,13 +40,13 @@ A different database in the cluster can be accessed with `\connect` (`\c`):
 
     \c postgres
 
-## Schemas
+## Schemas (#schemas)
 
 We can use `\dn` to list schemas within a database:
 
     \dn
 
-## Relations
+## Relations (#relations)
 
 Relations can be listed with `\d`:
 
@@ -65,7 +65,7 @@ to get even more information):
 
     \d my_schema.my_table
 
-## Quick Reference
+## Quick Reference (#quick-reference)
 
 Now we've introduced a lot of esoteric commands here that might be hard to
 remember, but luckily there's an easy trick. Psql has a few different internal
@@ -76,7 +76,7 @@ contains a quick reference for every "backslash command":
 
 If you're going to take one thing away from this article, make it `\?`.
 
-## Search Path
+## Search Path (#search-path)
 
 One other important piece to mention is the [`search_path`
 setting][search-path-docs], which has a few important functions:

--- a/content/articles/stripe-running.md
+++ b/content/articles/stripe-running.md
@@ -21,7 +21,7 @@ nowhere near this level of elevation gain or variation in terrain.
 
 !fig src="/assets/stripe-running/triple-peaks.png" caption="The daunting Triple Peaks run in San Francisco."
 
-## Analysis
+## Analysis (#analysis)
 
 Between the new social pressure and the new available routes, over the last
 month I've certainly _felt_ like I was running more, but it would be nice to

--- a/content/drafts/api-versioning.md
+++ b/content/drafts/api-versioning.md
@@ -5,9 +5,9 @@ title: API Versioning
 hook: Best practices for implementing an API versioning scheme.
 ---
 
-## Web API Versioning Schemes
+## Web API Versioning Schemes (#schemes)
 
-### Broad Versioning
+### Broad Versioning (#broad-versioning)
 
 Either prefixed or through something like an `Accept` header.
 
@@ -17,17 +17,17 @@ Twitter is still on V1. Twilio is still on "2010-04-01". Heroku is still on V3
 [1]. Stripe is still on V1 (although it its case the existence of prefix
 versioning is largely vestigial).
 
-### Implicit Versioning
+### Implicit Versioning (#implicit-versioning)
 
-### No Versioning
+### No Versioning (#no-versioning)
 
-### Hypermedia
+### Hypermedia (#hypermedia)
 
 Despite years of aggressive and sustained evangelism, it's failed to gain much
 of a foothold in any major APIs. It also has some major practical problems,
 such as the increased expense due to its chatty nature.
 
-## Stripe's Versioning Examined
+## Stripe's Versioning Examined (#stripe-versioning)
 
 Conveys major benefits, but has major downsides.
 

--- a/content/drafts/postgres.md
+++ b/content/drafts/postgres.md
@@ -7,7 +7,7 @@ hook: A listing of all useful Postgres features, tricks, and advice that I've
 location: San Francisco
 ---
 
-## Schemas
+## Schemas (#schemas)
 
 ### BIGINT and BIGSERIAL (#bigint-and-bigserial)
 
@@ -73,7 +73,7 @@ into memory. `jsonb` also supports indexing.
 
 There's a simple heuristic: always pick `jsonb`.
 
-### Partial Indexes
+### Partial Indexes (#partial-indexes)
 
 Postgres allows an index to be created with a `WHERE` clause. This can save a
 lot of storage space in a large table by allowing you to only build indexes
@@ -102,7 +102,7 @@ comes to times. I managed an old database that started storing times in Pacific
 and it was such an incredible pain amount of effort to fix (there were hundreds
 of time columns in total) that even years later it never happened.
 
-### Check Constraints
+### Check Constraints (#check-constraints)
 
 SQL allows `CHECK` constraints to be defined on a table. These will verify that
 an arbitrary boolean condition is true before allowing an insert or update.
@@ -130,7 +130,7 @@ suggest becoming intimately familiar with Postgres' built-in psql tool. It's an
 incredibly efficient way to quickly get visibility into and manage a running
 database.
 
-### Editor
+### Editor (#editor)
 
 Do you ever find it awkward editing queries from a prompt? Try this:
 
@@ -220,12 +220,12 @@ the parent transaction:
 \set ON_ERROR_ROLLBACK interactive
 ```
 
-## Operations
+## Operations (#operations)
 
 So you've already got a big database. Here's some basic operational advice on
 how to manage it.
 
-### Raise and Drop Indexes Concurrently
+### Raise and Drop Indexes Concurrently (#concurrently)
 
 When adding or removing an index, use the `CONCURRENTLY` keyword to avoid a write lock on the table:
 
@@ -240,7 +240,7 @@ The one caveat is that you can't run concurrent operations from inside a
 transaction, but especially when it comes to indexes, it's a trade that's well
 worthwhile.
 
-### Dangerous Operations
+### Dangerous Operations (#dangerous-operations)
 
 A major problem with databases is that it's not obvious what DDL operations are
 safe or unsafe when it comes to running them on a high-volume installation. The
@@ -259,23 +259,23 @@ Here are a list of safe versus unsafe operations:
   </table>
 </figure>
 
-### pg_stat_activity
+### pg_stat_activity (#pg-stat-activity)
 
 See running processes.
 
-## Features
+## Features (#features)
 
-### Listen/Notify
+### Listen/Notify (#listen-notify)
 
-## SQL
+## SQL (#sql)
 
-### Intervals
+### Intervals (#intervals)
 
 ``` sql
 SELECT now() - '1 month'::interval;
 ```
 
-### With Clauses
+### With Clauses (#with-clause)
 
 Names subselects
 
@@ -285,7 +285,7 @@ PVH: You can actually share a SQL query with another human being [2].
 WITH ()
 ```
 
-### Window Functions
+### Window Functions (#window-functions)
 
 ``` sql
 OVER PARTITION BY

--- a/content/drafts/qe.md
+++ b/content/drafts/qe.md
@@ -12,7 +12,7 @@ As QE3 continues to demonstrate that its nickname of QE-Infinity is well-deserve
 
 What follows is my attempt to explain QE in the simple and pragmatic style of the technical blog posts that I've read over the years (thus "for hackers"). Keep in mind that I'm an enthusiast but not an expert, and [welcome feedback and corrections](mailto:brandur@brandur.org).
 
-## Actors
+## Actors (#actors)
 
 Lets start with the basic and talk about the basic actors involved in the process:
 
@@ -20,7 +20,7 @@ Lets start with the basic and talk about the basic actors involved in the proces
 * *Federal Reserve System* (or the **Fed**): the central banking system of the United States. It was created in 1913 as a reaction to an economic panic in 1907 (where the NYSE fell 50% compared to 1906) and tasked by Congress with the responsibilities of maximizing US employment, stabilizing prices, and moderating long-term interest rates. In response to the global financial crisis of 2007-08, it has initiated qualititative easing in an attempt to mitigate the effects of the recession on the US economy. The Fed buys and sells treasuries at auction with its primary dealers.
 * *Primary dealers*: ~20 banks permitted to trade directly with the Fed. When the Fed auctions securities, primary dealers are _required_ to participate. The vast majority of treasuries are traded through the primary dealers to other entities worldwide. [Lists of primary dealers](http://en.wikipedia.org/wiki/Primary_dealer#Current_list) are easily available and include well-known names like **BMO**, **Goldman Sachs**, and **JP Morgan**.
 
-## Fractional-reserve Banking
+## Fractional-reserve Banking (#fractional-reserve-banking)
 
 [Fractional-reserve banking](http://en.wikipedia.org/wiki/Fractional_reserve_banking) is a form of banking carried out worldwide that's important to understanding the whole story of QE. Under this system, banks retain reserves only equal to the a _fraction_ of the their total deposits, with that fraction's amount being sufficient to satisfy demand for withdrawals. The rest of the money can be invested or loaned out.
 
@@ -30,7 +30,7 @@ In the US, the Fed stipulates the reserve requirements for US banks and banks op
 
 The total reserves plus the total currency in circulation is known as the **[monetary base](http://en.wikipedia.org/wiki/Monetary_base)**.
 
-## QE. Step by Step.
+## QE. Step by Step. (#step-by-step)
 
 Now that we have the backstory in place, let's dive into how QE actually works:
 
@@ -39,7 +39,7 @@ Now that we have the backstory in place, let's dive into how QE actually works:
 1. After the transaction, the primary dealers have now traded the treasuries amongst their assets for a credit that shows up in the books they keep with the Fed.
 1. This credit usually becomes part of that bank's _required reserves_ with the Fed, so they can now proceed to lend out more money than they could before. Fractional reserve banking ensures that whatever amount the reserve increased by is effectively multiplied, and therefore its effect on the money supply has a magnified effect, _but_ the increase in reserve isn't cash itself (remember, it's just a credit on the Fed's balance sheet) so the bank has to find liquidity elsewhere if it wants to loan it out.
 
-## Example
+## Example (#example)
 
 Let's throw some numbers into this equation just to illustrate the full effect. We're going to examine the balance sheets of the Treasury, the Fed, and the imaginary primary dealer **Bank A** before and after a round of QE.
 
@@ -195,11 +195,11 @@ So in other words, the inflationary pressure here may not be that much stronger 
 
 Luckily, we do have some idea as to what's going on as [the Fed tracks the monetary base of the United States](http://www.federalreserve.gov/releases/H3/Current/). The monetary base as of January 2014 is $3,753B, almost a trillion dollars larger than the base of $2,741B in January 2013. That seems like an enormous increase, but if you compare the total reserves of January 2014 ($2,582B) to that of January 2013 ($1,637B) you'll notice that this number is also almost a trillion dollars larger, showing that the increase in reserves is almost entirely responsible for the overall increase to the monetary base. The fact that those reserves are locked up tight &mdash; no bank can lend reserves except to another bank &mdash; means that their effect on inflation is lower than one might expect.
 
-## Other Effects
+## Other Effects (#other-effects)
 
 The Fed's purchase of large numbers of treasuries is enough to push down the **yields** on all government bonds, making them a less attractive investment. This shifts the risk curve and leads investors towards assets like stocks and corporate bonds, pushing the price of those assets higher. These increased prices leads to a **[wealth effect](http://en.wikipedia.org/wiki/Wealth_effect)**, meaning that the increase in perceived wealth improves confidence and leads to more spending, thus stimulating the economy. The effectiveness of this strategy is also difficult to measure directly, but we can observe the price increases in many types of assets over the last few years.
 
-## References
+## References (#references)
 
 * [Why quantitative easing isn't printing money](http://www.cnbc.com/id/100760150)
 * [What is the purpose of QE?](http://www.ritholtz.com/blog/2012/12/what-is-the-purpose-of-qe/)

--- a/content/fragments/2015-update.md
+++ b/content/fragments/2015-update.md
@@ -8,7 +8,7 @@ As we're nearing the end of the year, it's time for a quick revisit to my
 assembled [resolutions for 2015](/fragments/2015-resolutions). Verdict: not
 good.
 
-## Personal
+## Personal (#personal)
 
 > _Run_ 1700 km.
 
@@ -40,7 +40,7 @@ I'm writing, but nowhere close to this frequency. (0/1)
 
 Abject failure. Averaging zero times a week. (0/1)
 
-## Work
+## Work (#work)
 
 > Ship a sustainable real-time API (i.e. event stream).
 
@@ -57,13 +57,13 @@ track to take it to production. (1/1)
 
 I made it once so far. (0.5/1)
 
-## Bonus
+## Bonus (#bonus)
 
 > Get two surfing trips in and get moderately good by doing so.
 
 I didn't make it on any surfing vacations so far. (0/1)
 
-## Summary
+## Summary (#summary)
 
 **Score:** 2.5/9. Fairing _very_ poorly.
 

--- a/content/fragments/avast.md
+++ b/content/fragments/avast.md
@@ -19,7 +19,7 @@ through hoops to correct it. They asserted that it wasn't just reasonable, but
 standard practice in the antivirus industry, then followed up with a trailing
 platitude on how user safety was their top priority.
 
-## Ghosts of the Past
+## Ghosts of the Past (#ghosts-of-the-past)
 
 As the lower bound of exploits becomes increasingly handled by ever more secure
 operating systems, and the upper bound becomes increasingly more sophisticated

--- a/content/fragments/going-static.md
+++ b/content/fragments/going-static.md
@@ -13,7 +13,7 @@ Overall, it was a good opportunity to do general housecleaning, and to write
 tests for modules that didn't previously have any, but the major impetus for
 the move was for bigger reasons. I've touched on a few of them below.
 
-## Static Is Fast
+## Static Is Fast (#fast)
 
 The site is now stored in S3 after it's built from Travis, and then served from
 a CloudFront distribution at one of their [~40 edge locations][cloudfront] from
@@ -26,7 +26,7 @@ stack is all hosted by one company (AWS) rather than being straddled across
 CloudFlare and Heroku, and that I now have fine-grain control over the behavior
 of my CDN.
 
-## Static Is Resilient
+## Static Is Resilient (#resilient)
 
 The previous site had a few dependencies in the form of a Postgres database
 used to procure tweets, books, runs, etc., and depended on Flickr in some cases
@@ -39,7 +39,7 @@ The new system still uses Postgres and Flickr as sources, but they're only
 referenced during the site's build step. Any trouble will error the build and
 cancel deployment, so no user will ever see a problem.
 
-## Static Is Future-proof
+## Static Is Future-proof (#futureproof)
 
 I've recently been concerned with just how many minor tweaks I had to make to
 old the Ruby codebase just to keep it modern and alive. For example, it's good
@@ -69,7 +69,7 @@ build artifact itself in S3 which is a simple collection of HTML, CSS, and
 image files that will run anywhere, including a browser pointed at localhost.
 It's trivially simple to move them around or archive them permanently.
 
-## There and Back Again
+## There and Back Again (#there-and-back-again)
 
 Considering that I originally started publishing on the original static site
 generators like Movable Type, then went dynamic after the static site craze of

--- a/content/fragments/macbook-12.md
+++ b/content/fragments/macbook-12.md
@@ -20,7 +20,7 @@ I guess.
 
 ![The 12" MacBook](/assets/macbook-12/macbook-12.jpg)
 
-## The Good
+## The Good (#good)
 
 The laptop's **retina display** is absolutely beautiful. A full screen terminal
 with anti-aliased Inconsolata is by far the most gorgeous development
@@ -47,7 +47,7 @@ work entire days without visiting a power outlet, and so far I've never come
 close to running out of juice. (That said, I keep a pretty close eye on `top -o
 cpu` for processes that are out of line.)
 
-## The Bad
+## The Bad (#bad)
 
 The **keyboard** is about as disappointing as I expected. A lot of review sites
 claim that it's something "that you'll have to get used to", and to some degree
@@ -73,7 +73,7 @@ except that its narrower profile allowed me to fit it through the mouth of my
 bag more easily. Unfortunately, I think the major gains in this area have
 already been gotten.
 
-## The Ugly
+## The Ugly (#ugly)
 
 The **peripheral ports** are unquestionably the worst thing about the new
 MacBook. At only one port I find myself constantly having to make hard
@@ -89,7 +89,7 @@ a huge selection of external devices, and everything else under the sun. The
 trouble is that many of these new displays are naturally going to ship at 4k
 resolution, a number that will be truly daunting for the underpowered MacBook.
 
-## Summary
+## Summary (#summary)
 
 I _really_ like using the new MacBook. The screen, battery life, and smaller
 power brick make a big enough difference for me that they outweigh all the new

--- a/content/fragments/safety-razors.md
+++ b/content/fragments/safety-razors.md
@@ -14,7 +14,7 @@ try to sell the idea a bit.
 
 <a href="https://www.flickr.com/photos/brandurleach/23656853583/"><img src="/assets/fragments/safety-razors/razor.jpg"></a>
 
-## Why You Should Try It
+## Why You Should Try It (#why)
 
 The safety razor has some major advantages over your everyday supermarket
 brand:
@@ -35,7 +35,7 @@ blade once a week, so a $12 50-pack of feather blades lasts me a whole year.
 I'm getting a great shave that entire time instead of pushing my blades to the
 absolute limit because I'm afraid of the cost of refill cartridges.
 
-## Fear, Uncertainty, Doubt
+## Fear, Uncertainty, Doubt (#fud)
 
 A common misconception is that safety razors are dangerous, which probably
 stems from a confusion between a [straight razor][straight-razor] and a safety
@@ -54,7 +54,7 @@ moisturization process to avoid cuts on the sensitive skin of the lower neck
 (in my experience it's best to shave right after a shower in a humid room), but
 that's really the only catch.
 
-## Starter Kit
+## Starter Kit (#starter-kit)
 
 I have a very basic kit that includes these products:
 

--- a/content/fragments/two-stars.md
+++ b/content/fragments/two-stars.md
@@ -10,7 +10,7 @@ though I'd write down a few thoughts about the experience because I may not be
 back in a while. The restaurant in question is Falco, located on the
 twenty-seventh floor of the Westin in Leipzig.
 
-## The Ambience
+## The Ambience (#ambience)
 
 Falco's official website describes itself as "closer to heaven than earth".
 Regardless of the quality of its food, it's at least an description for its
@@ -31,7 +31,7 @@ another two bussed them from the trays to the table. After the arrival of any
 dish, a member of staff would come by to present its backstory and composition.
 At all times service was never more than a glance away.
 
-## The Menu
+## The Menu (#menu)
 
 The menu was nothing short of hilarious in its raw unintelligibility. An
 eclectic mixture of random font sizes and styles, erratic whitespace and
@@ -47,7 +47,7 @@ and a mid-nineties copy of Microsoft Word.
 The menu didn't affect the experience, but there was clear irony that the one
 at the McDonalds two blocks away was better-designed.
 
-## The Food
+## The Food (#food)
 
 As expected, the food was delicious and beautifully presented. A common theme
 to the design of each dish was to have a very large plate with the food itself
@@ -59,7 +59,7 @@ which was a nice touch. We got everything from small pieces of marinated fruit
 balanced on toothpicks atop of a piece of driftwood to small balls of chocolate
 nestled in their own zen garden of sugar.
 
-## The Score
+## The Score (#score)
 
 Being someone who's happy with a 3€ doner kebab, I don't often come out of an
 expensive meal feeling like my money's been well-spent. I did enjoy my

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -21,15 +21,13 @@ rx="^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$"
 
 dirs="content/articles/* content/drafts/* content/fragments/* content/fragments-drafts/*"
 
-grep --help
-
 # Use ag for Macs (where grep lacks PCRE) and fall back to gnugrep for Linux
 # systems. Macs without ag installed won't be able to run this script
 # successfully.
-if [[ $(which ag) ]]; then
+if command -v ag >/dev/null; then
     bad_headers=$(ag -C 0 "$rx" $dirs)
 # grep will exit with 1 for no match and 2 if we passed a bad option
-elif [[ $(which grep) && $(echo abc | grep --perl-regexp def) -eq 1 ]]; then
+elif command -v grep > /dev/null && (echo 'abc' | grep --perl-regexp abc >/dev/null 2>&1); then
     bad_headers=$(grep --perl-regexp "$rx" $dirs)
 else
     echo "no suitable matchers"

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -19,7 +19,7 @@
 # have to add new characters to the class, but it's mostly okay for now.
 rx="^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$"
 
-dirs="content/articles/* content/drafts/*"
+dirs="content/articles/* content/drafts/* content/fragments/* content/fragments-drafts/*"
 
 # Use ag for Macs (where grep lacks PCRE) and fall back to gnugrep for Linux
 # systems. Macs without ag installed won't be able to run this script

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -17,7 +17,7 @@
 # the life of me I can't get it to not match newlines, which leads to a huge
 # multi-line match (even in single line mode). This sucks because I'll probably
 # have to add new characters to the class, but it's mostly okay for now.
-rx="^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$"
+rx="^###?#?#? [A-Za-z0-9.:'/\-_ ]+(?! \(#.*\))$"
 
 dirs="content/articles/* content/drafts/* content/fragments/* content/fragments-drafts/*"
 

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# That first character class should probably be something like [^\(\n], but for
+# the life of me I can't get it to not match newlines, which leads to a huge
+# multi-line match (even in single line mode). This sucks because I'll probably
+# have to add new characters to the class, but it's mostly okay for now.
+bad_headers=$(ag -C 0 '^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$' content/articles/* content/drafts/*)
+
+if [[ -n "${bad_headers}" ]]; then
+    echo "!!! the following headers do not have IDs: "
+    echo "${bad_headers}"
+    exit 1
+fi

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
 
+#
+# check_headers.sh
+#
+# This project uses a custom Markdown addition that allows headers to be
+# annotated with an ID so that we can name their permalink. This looks
+# something like this:
+#
+#     ## The Best Section (#the-best-section)
+#
+# Unfortunately, these are easy to forget, and when I do, the result is a
+# generically-named header. This script checks to make sure that all headers
+# have an identifier. It runs in CI.
+
 # That first character class should probably be something like [^\(\n], but for
 # the life of me I can't get it to not match newlines, which leads to a huge
 # multi-line match (even in single line mode). This sucks because I'll probably
 # have to add new characters to the class, but it's mostly okay for now.
-bad_headers=$(ag -C 0 '^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$' content/articles/* content/drafts/*)
+rx="^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$"
+
+dirs="content/articles/* content/drafts/*"
+
+# Use ag for Macs (where grep lacks PCRE) and fall back to gnugrep for Linux
+# systems. Macs without ag installed won't be able to run this script
+# successfully.
+if [[ $(which ag) ]]; then
+    bad_headers=$(ag -C 0 "$rx" $dirs)
+# grep will exit with 1 for no match and 2 if we passed a bad option
+elif [[ $(which grep) && $(echo abc | grep --perl-regexp def 2> /dev/null) -eq 1 ]]; then
+    bad_headers=$(grep --perl-regexp "$rx" $dirs)
+else
+    echo "no suitable matchers"
+    exit 1
+fi
 
 if [[ -n "${bad_headers}" ]]; then
     echo "!!! the following headers do not have IDs: "

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -21,13 +21,15 @@ rx="^###?#?#? [A-Za-z0-9'\-]+(?! \(#.*\))$"
 
 dirs="content/articles/* content/drafts/* content/fragments/* content/fragments-drafts/*"
 
+grep --help
+
 # Use ag for Macs (where grep lacks PCRE) and fall back to gnugrep for Linux
 # systems. Macs without ag installed won't be able to run this script
 # successfully.
 if [[ $(which ag) ]]; then
     bad_headers=$(ag -C 0 "$rx" $dirs)
 # grep will exit with 1 for no match and 2 if we passed a bad option
-elif [[ $(which grep) && $(echo abc | grep --perl-regexp def 2> /dev/null) -eq 1 ]]; then
+elif [[ $(which grep) && $(echo abc | grep --perl-regexp def) -eq 1 ]]; then
     bad_headers=$(grep --perl-regexp "$rx" $dirs)
 else
     echo "no suitable matchers"


### PR DESCRIPTION
This project uses a custom Markdown addition that allows headers to be
annotated with an ID so that we can name their permalink. That looks
something like this:

``` markdown
## My Header (#my-header)
```

Unfortunately, these are easy to forget, and when I do, the result is a
generically-named header. This script checks to make sure that all headers
have an identifier. It runs in CI.