### PR TITLE
Publish "How Ruby Allocates Memory"

### DIFF
--- a/content/articles/ruby-memory.md
+++ b/content/articles/ruby-memory.md
@@ -1,6 +1,6 @@
 ---
 title: "The Limits of Copy-on-write: How Ruby Allocates Memory"
-published_at: 2017-08-24T13:39:04Z
+published_at: 2017-08-28T14:07:33Z
 hook: Why Ruby's scheme for memory allocation doesn't play
   nicely with copy-on-write, and how a compacting garbage
   collector will help.


### PR DESCRIPTION
Why Ruby's scheme for memory allocation doesn't play nicely with copy-on-write, and how a compacting garbage collector will help.