### PR TITLE
Switch to `position: sticky`

### DIFF
--- a/content/stylesheets/main.sass
+++ b/content/stylesheets/main.sass
@@ -52,7 +52,7 @@ body
   // thinks it needs more space.
   min-width: 100px
 
-.nav-inner, .nav-inner-unfixed, .toc-inner
+.nav-inner, .toc-inner
   width: 100px
 
   // Looks kind of interesting, but doesn't seem to quite fit.
@@ -71,10 +71,15 @@ body
 
 .top-nav
   margin-left: 40px
+  margin-top: 150px
 
   .nav-inner
     overflow: auto
-    position: fixed
+    position: -webkit-sticky
+    position: sticky
+
+    // Top is required for sticky
+    top: 50px
 
   nav
     font-family: $sans_serif

--- a/views/articles/show.ace
+++ b/views/articles/show.ace
@@ -13,7 +13,7 @@
         .flag
       {{end}}
       .top-nav
-        div class="{{if eq .Article.Image ""}}nav-inner{{else}}nav-inner-unfixed{{end}}"
+        .nav-inner
           = include views/_nav
           .nav-extra-content
             .divider


### PR DESCRIPTION
TIL that this is built into CSS now. Switch off of `fixed` and over to
`sticky` for a slight improvement on normal article pages, but a major
improvement for articles that have a header image.

https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning