### PR TITLE
Upgrade to Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.9
 
 # magic word to use faster/newer container-based architecture
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ else
 endif
 
 install:
-	go install $(shell go list ./... | egrep -v '/vendor/')
+	go install ./...
 
 # Invalidates CloudFront's cache for paths specified in PATHS.
 #
@@ -102,17 +102,17 @@ invalidate-indexes: check-aws-keys check-cloudfront-id
 # The exit 255 trick ensures that xargs will actually bubble a failure back up
 # to the entire command.
 lint:
-	go list ./... | egrep -v '/vendor/' | sed "s|^github\.com/brandur/sorg|.|" | xargs -I{} -n1 sh -c '$(GOPATH)/bin/golint -set_exit_status {} || exit 255'
+	go list ./... | xargs -I{} -n1 sh -c '$(GOPATH)/bin/golint -set_exit_status {} || exit 255'
 
 serve:
 	$(GOPATH)/bin/sorg-serve
 
 test:
 	psql postgres://localhost/sorg-test < testing/black_swan.sql > /dev/null
-	go test $(shell go list ./... | egrep -v '/vendor/')
+	go test ./...
 
 vet:
-	go vet $(shell go list ./... | egrep -v '/vendor/')
+	go vet ./...
 
 # Note that we use the CONTENT_ONLY flag on the build here. We're watching for
 # changes in content directories, so don't bother rebuilding pages generated


### PR DESCRIPTION
Upgrades to Go 1.9. The biggest win here is that `vendor` is no longer
included in `./..` splats so we can get rid of a lot of hackiness that
was previously needed in the `Makefile`.