### PR TITLE
Clarify required transaction isolation level

### DIFF
--- a/content/articles/job-drain.md
+++ b/content/articles/job-drain.md
@@ -118,7 +118,7 @@ jobs through to Sidekiq:
 acquire_lock(:enqueuer) do
 
   loop do
-    DB.transaction do
+    DB.transaction(isolation: :repeatable_read) do
       # For best efficiency, pull jobs in large batches.
       job_batch = StagedJobs.order('id').limit(1000)
 


### PR DESCRIPTION
The default transaction isolation level in Postgres is "Read Committed". Unless I'm mistaken, this opens up a race condition between the following two statements:

```ruby
job_batch = StagedJobs.order('id').limit(1000)
```
```ruby
StagedJobs.where('id <= ?', job_batch.last).delete
```

I.e. with `read committed` the following race might happen:

```
TX1: begin
TX2: begin
TX1: insert job 1
TX2: insert job 2
TX2: commit
ENQUEUER: begin
ENQUEUER: SELECT * FROM jobs ... (returns job 2, but not job 1)
TX1: commit (makes job 1 visible to enqueuer)
ENQUEUER: DELETE FROM jobs WHERE id <= 2 (deletes job 1 and 2, even so job 1 wasn't processed)
ENQUEUER: commit
```

Let me know if that makes sense or if I'm confused :).

Otherwise thank you so much for this great article, as well as all the others you've written.

PS: Part of what makes this a subtle issue is that the serial increment happens outside of MVCC right when the job row is inserted, rather than when the transaction commits.