### PR TITLE
Detect image locations for hook/Twitter card

### DIFF
--- a/content/articles/acid.md
+++ b/content/articles/acid.md
@@ -6,8 +6,6 @@ hook: On ensuring system integrity, operability, and
   correctness through a solid foundational database, and
   how ACID transactions and strong constraints work in your
   favor. Why to prefer Postgres over MongoDB.
-hook_image: true
-twitter_image: true
 ---
 
 In 1983, Andreas Reuter and Theo Härder coined the acronym

--- a/content/articles/api-paradigms.md
+++ b/content/articles/api-paradigms.md
@@ -5,8 +5,6 @@ location: San Francisco
 hook: Musings on the next API technology, and whether REST-ish
   JSON over HTTP is just "good enough" to never be displaced
   in a significant way.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=14003134
 ---
 

--- a/content/articles/breaktime.md
+++ b/content/articles/breaktime.md
@@ -4,7 +4,6 @@ published_at: 2014-02-02T18:15:28Z
 location: San Francisco
 hook: In search of an alternative to BreakTime. The
   discovery of a very classical solution.
-hook_image: true
 ---
 
 A few years ago I took the plunge and started using

--- a/content/articles/heroku-values.md
+++ b/content/articles/heroku-values.md
@@ -4,8 +4,6 @@ image: "/assets/heroku-values/heroku-values.jpg"
 location: San Francisco
 published_at: 2015-11-05T06:20:16Z
 title: My Heroku Values
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=14286143
 ---
 

--- a/content/articles/idempotency-keys.md
+++ b/content/articles/idempotency-keys.md
@@ -6,8 +6,6 @@ hook: Building resilient services by identifying foreign
   state mutations and grouping local changes into
   restartable atomic phases so that every request can be
   driven to completion.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=15569478
 ---
 

--- a/content/articles/interfaces.md
+++ b/content/articles/interfaces.md
@@ -5,8 +5,6 @@ location: San Francisco
 hook: How we overvalue the wrong technology and novel
   aspects of interface design at the expense of substantial
   gains to our productivity.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=13733777
 ---
 

--- a/content/articles/minimalism.md
+++ b/content/articles/minimalism.md
@@ -5,8 +5,6 @@ location: San Francisco
 hook: Practicing minimalism with the lofty goal of total
   ephemeralization to build coherent, stable, and operable
   stacks.
-hook_image: true
-twitter_image: true
 attributions: Photographs by <strong><a href="https://www.flickr.com/photos/i-am-mclovin/14601998033/">Ben Harrington</a></strong> (SR-71), <strong><a href="https://www.flickr.com/photos/learnscope/5032942270/">Robyn Jay</a></strong> (embers of a burning fire), and <strong><a href="https://www.flickr.com/photos/alamin_bd/22969073683/">Md. Al Amin</a></strong> (boat and sky). Licensed under Creative Commons BY-NC-ND 2.0, BY-SA 2.0, and CC BY 2.0 respectively.
 ---
 

--- a/content/articles/newsletters.md
+++ b/content/articles/newsletters.md
@@ -3,8 +3,6 @@ title: "Pseudo-HTML and Pidgin CSS: Building an Email Newsletter"
 published_at: 2017-08-02T14:52:31Z
 hook: Building a toolchain for sending a newsletter, and
   the dismal state of HTML and CSS in email.
-hook_image: true
-twitter_image: true
 ---
 
 After a recent trip to Portland, I decided to try writing a

--- a/content/articles/page.md
+++ b/content/articles/page.md
@@ -3,8 +3,6 @@ hook: How the page almost transitioned successfully to the
   digital world, but is in decline in new media. The
   lessons that we can learn from this age-old design
   element, and why we should hope for its re-emergence.
-hook_image: true
-twitter_image: true
 image: "/assets/page/page.jpg"
 location: San Francisco
 published_at: 2014-01-26T18:56:46Z

--- a/content/articles/postgres-atomicity.md
+++ b/content/articles/postgres-atomicity.md
@@ -5,8 +5,6 @@ location: San Francisco
 hook: A dive into the mechanics that allow Postgres to
   provide strong atomic guarantees despite the chaotic
   entropy of production.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=15027870
 ---
 

--- a/content/articles/postgres-reads.md
+++ b/content/articles/postgres-reads.md
@@ -6,8 +6,6 @@ published_at: 2017-11-17T22:02:56Z
 hook: Scaling out operation with read replicas and avoiding
   the downside of stale reads by observing replication
   progress.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=15726376
 ---
 

--- a/content/articles/redis-streams.md
+++ b/content/articles/redis-streams.md
@@ -5,8 +5,6 @@ location: San Francisco
 hook: Building a log-based architecture that's fast,
   efficient, and resilient on the new stream data structure
   in Redis.
-hook_image: true
-twitter_image: true
 hn_link: https://news.ycombinator.com/item?id=15653544
 ---
 

--- a/content/articles/stripe-running.md
+++ b/content/articles/stripe-running.md
@@ -3,7 +3,6 @@ hook: Crunching running data with prepared statements in Postgres.
 location: San Francisco
 published_at: 2015-10-24T20:55:32Z
 title: Running at Stripe
-hook_image: true
 ---
 
 One pleasant surprise of Stripe's internal culture was the existence of a

--- a/content/articles/webhooks.md
+++ b/content/articles/webhooks.md
@@ -6,8 +6,6 @@ hook: When it comes to streaming APIs, there's now a lot of
   great options like SSE, GraphQL subscriptions, and GRPC
   streams. Let's examine whether webhooks are still a good
   choice in 2017.
-hook_image: true
-twitter_image: true
 attributions: Thanks to <a
   href="https://twitter.com/spencercdixon">Spencer
   Dixon</a> for review.

--- a/content/articles/x100s-hack.md
+++ b/content/articles/x100s-hack.md
@@ -4,8 +4,6 @@ hook: If you find that the price tag for a Fuji-official adapter ring for the X1
 location: San Francisco
 published_at: 2014-08-03T16:50:19Z
 title: A Cheap X100S Filter Ring Hack
-hook_image: true
-twitter_image: true
 ---
 
 The [official Fujifilm X100/X100S 49 mm adapter ring](http://www.amazon.com/Fujifilm-AR-X100-Adapter-Ring-49mm/dp/B004MME69S) which allows you to mount extra filters onto your lens will run you about $40, which is a little steep considering that its entire role in life is to act as an expensive spacer.

--- a/content/drafts/microservices-and-the-monolith.md
+++ b/content/drafts/microservices-and-the-monolith.md
@@ -3,8 +3,6 @@ title: Microservices and the Monolith
 published_at: 2017-01-05T16:41:25Z
 hook: Microservices may be out of vogue, but we should be
   wary of overcompensation.
-hook_image: true
-twitter_image: true
 ---
 
 About three years ago, the idea of a service-oriented

--- a/content/drafts/ruby-scale.md
+++ b/content/drafts/ruby-scale.md
@@ -4,8 +4,6 @@ published_at: 2017-04-18T14:23:28Z
 location: San Francisco
 hook: The challenges of scaling and operating a big Ruby
   codebase (that are not related to performance).
-hook_image: true
-twitter_image: true
 ---
 
 Ruby is a beautiful language. Speaking from experience,

--- a/content/fragments/airpods.md
+++ b/content/fragments/airpods.md
@@ -2,7 +2,6 @@
 title: AirPods
 published_at: 2017-03-29T14:44:33Z
 image: /assets/fragments/airpods/vista.jpg
-twitter_image: true
 hook: I'm happy to be cheering from the bleachers as Apple
   makes their first home run in years.
 ---

--- a/content/fragments/ipad-mini.md
+++ b/content/fragments/ipad-mini.md
@@ -2,7 +2,6 @@
 title: The iPad Mini
 published_at: 2016-06-12T22:26:17Z
 image: /assets/fragments/ipad-mini/vista.jpg
-twitter_image: true
 hook: An ode to one of my favorite Apple devices.
 ---
 

--- a/content/fragments/ivy.md
+++ b/content/fragments/ivy.md
@@ -1,7 +1,6 @@
 ---
 title: Ivy
 published_at: 2016-08-24T03:12:31Z
-twitter_image: true
 image: /assets/fragments/ivy/vista.jpg
 hook: Stripe's new home in SOMA.
 ---

--- a/content/fragments/monkeybrains.md
+++ b/content/fragments/monkeybrains.md
@@ -2,7 +2,6 @@
 title: MonkeyBrains
 published_at: 2016-01-23T01:15:58Z
 image: /assets/fragments/monkeybrains/vista.jpg
-twitter_image: true
 hook: A very brief review of the local San Francisco ISP.
 ---
 

--- a/content/fragments/sprawl-blues.md
+++ b/content/fragments/sprawl-blues.md
@@ -2,7 +2,6 @@
 title: The Sprawl Blues
 published_at: 2016-01-03T22:18:36Z
 image: /assets/fragments/sprawl-blues/vista.jpg
-twitter_image: true
 hook: On sprawl and commute times in North America.
 ---
 

--- a/content/fragments/wgt-2015.md
+++ b/content/fragments/wgt-2015.md
@@ -2,7 +2,6 @@
 title: WGT 2015 Abstract
 published_at: 2015-05-29T13:34:59Z
 image: /assets/fragments/wgt-2015/vista.jpg
-twitter_image: true
 hook: A whirlwind tour of Wave-Gotik-Treffen 2015.
 ---
 

--- a/content/fragments/your-name.md
+++ b/content/fragments/your-name.md
@@ -2,7 +2,6 @@
 title: Your Name
 published_at: 2017-04-11T01:26:59Z
 image: /assets/fragments/your-name/vista.jpg
-twitter_image: true
 hook: A short review of Makoto Shinka's latest animated
   film.
 ---

--- a/views/articles/index.ace
+++ b/views/articles/index.ace
@@ -25,9 +25,9 @@
               ul
                 {{range .Articles}}
                   li
-                    {{if .HookImage}}
+                    {{if .HookImageURL}}
                       a href="/{{.Slug}}"
-                        img src="/assets/{{.Slug}}/hook.jpg" data-rjs="2"
+                        img src="{{.HookImageURL}}" data-rjs="2"
                     {{end}}
                     .title
                       a href="/{{.Slug}}"


### PR DESCRIPTION
Detects image locations and generates URLs automatically for hook and
Twitter card images. This carries the advantage of (1) less boilerplate
in YAML frontmatter (all of which has been removed), and (2) allows us
to support multiple formats (I want to have PNG card and hook images).