### PR TITLE
Group the OR clause in distkey/sortkey filter

### DIFF
--- a/content/fragments/redshift-keys.md
+++ b/content/fragments/redshift-keys.md
@@ -14,8 +14,8 @@ SELECT "column", type, distkey, sortkey
 FROM pg_table_def
 WHERE schemaname = 'logs' AND
     tablename = 'bapi' 
-AND distkey = true
-    OR sortkey <> 0;
+AND (distkey = true
+    OR sortkey <> 0);
 
  column  |            type             | distkey | sortkey
 ---------+-----------------------------+---------+---------


### PR DESCRIPTION
Without the grouping, we end up returning **all** columns, from all schemas + tables, that have sortkey <> 0.