### PR TITLE
Upgrade to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10"
+  - "1.11"
 
 # magic word to use faster/newer container-based architecture
 sudo: false


### PR DESCRIPTION
Not strictly needed for anything, but just to stay on the latest
release.