### PR TITLE
Generate a Postgres-specific content feed

### DIFF
--- a/content/articles/acid.md
+++ b/content/articles/acid.md
@@ -6,6 +6,7 @@ hook: On ensuring system integrity, operability, and
   correctness through a solid foundational database, and
   how ACID transactions and strong constraints work in your
   favor. Why to prefer Postgres over MongoDB.
+tags: ["postgres"]
 ---
 
 In 1983, Andreas Reuter and Theo Härder coined the acronym

--- a/content/articles/postgres-atomicity.md
+++ b/content/articles/postgres-atomicity.md
@@ -5,6 +5,7 @@ location: San Francisco
 hook: A dive into the mechanics that allow Postgres to
   provide strong atomic guarantees despite the chaotic
   entropy of production.
+tags: ["postgres"]
 hn_link: https://news.ycombinator.com/item?id=15027870
 ---
 

--- a/content/articles/postgres-connections.md
+++ b/content/articles/postgres-connections.md
@@ -6,6 +6,7 @@ hook: Hitting the limit for maximum allowed connections is
   a common operational problem in Postgres. Here we look at
   a few techniques for managing connections and making
   efficient use of those that are available.
+tags: ["postgres"]
 hn_link: https://news.ycombinator.com/item?id=18220906
 ---
 

--- a/content/articles/postgres-default.md
+++ b/content/articles/postgres-default.md
@@ -4,6 +4,7 @@ published_at: 2018-08-28T16:46:39Z
 hook: How a seemingly minor enhancement in Postgres 11
   fills one of the system's biggest operational holes.
 location: San Francisco
+tags: ["postgres"]
 hn_link: https://news.ycombinator.com/item?id=17864837
 ---
 

--- a/content/articles/postgres-queues.md
+++ b/content/articles/postgres-queues.md
@@ -4,6 +4,7 @@ hook: How Postgres' concurrency model coupled with long-lived transactions can d
 location: San Francisco
 published_at: 2015-05-18T23:13:23Z
 title: Postgres Job Queues & Failure By MVCC
+tags: ["postgres"]
 hn_link: https://news.ycombinator.com/item?id=9576864
 ---
 

--- a/content/articles/postgres-reads.md
+++ b/content/articles/postgres-reads.md
@@ -6,6 +6,7 @@ published_at: 2017-11-17T22:02:56Z
 hook: Scaling out operation with read replicas and avoiding
   the downside of stale reads by observing replication
   progress.
+tags: ["postgres"]
 hn_link: https://news.ycombinator.com/item?id=15726376
 ---
 

--- a/content/articles/sortsupport.md
+++ b/content/articles/sortsupport.md
@@ -5,6 +5,7 @@ location: San Francisco
 hook: How Postgres makes sorting really fast by comparing
   small, memory-friendly abbreviated keys as proxies for
   arbitrarily large values on the heap.
+tags: ["postgres"]
 ---
 
 Most often, there's a trade off involved in optimizing

--- a/content/drafts/postgres-btree.md
+++ b/content/drafts/postgres-btree.md
@@ -3,5 +3,6 @@ title: Descending the Postgres B-tree
 published_at: 2018-10-01T15:23:04Z
 location: San Francisco
 hook: TODO
+tags: ["postgres"]
 ---
 

--- a/content/drafts/postgres-serializable.md
+++ b/content/drafts/postgres-serializable.md
@@ -3,6 +3,7 @@ title: How Postgres Makes Transactions Serializable
 published_at: 2018-09-07T15:36:33Z
 location: San Francisco
 hook: TODO
+tags: ["postgres"]
 ---
 
 In my decades working with computers, `SERIALIZABLE`

--- a/content/drafts/postgres.md
+++ b/content/drafts/postgres.md
@@ -5,6 +5,7 @@ hook: A listing of all useful Postgres features, tricks, and advice that I've
   accumulated over the years and which aren't easy to discover without someone
   telling you about them first.
 location: San Francisco
+tags: ["postgres"]
 ---
 
 ## Schemas (#schemas)

--- a/content/drafts/sortsupport-inet.md
+++ b/content/drafts/sortsupport-inet.md
@@ -4,6 +4,7 @@ title: "Designing SortSupport Abbreviated Keys for
 published_at: 2019-02-03T20:27:44Z
 location: San Francisco
 hook: TODO
+tags: ["postgres"]
 ---
 
 A few weeks ago, I wrote about [how SortSupport works in

--- a/content/drafts/strong-data-constraints.md
+++ b/content/drafts/strong-data-constraints.md
@@ -3,6 +3,7 @@ title: Building Safe Systems With Strong Data Constraints
 published_at: 2019-01-14T16:25:00Z
 location: San Francisco
 hook: TODO
+tags: ["postgres"]
 ---
 
 A common source of bugs in data-backed software is when an


### PR DESCRIPTION
Generates a Postgres-specific content feed for prospective use with
Planet PostgreSQL (located at `/articles-postgres.atom`).