### PR TITLE
Typo fix in idempotency-keys.md

### DIFF
--- a/content/articles/idempotency-keys.md
+++ b/content/articles/idempotency-keys.md
@@ -144,7 +144,7 @@ Let's look at a few examples of things that can go wrong:
   due to a constraint violation or a database connectivity
   problem.
 * Our call to Stripe could time out, leaving it unclear
-  whether our charge when through or not.
+  whether our charge went through or not.
 * Contacting Mailgun to send the receipt could fail,
   leaving the user with a credit card charge but no formal
   notification of the transaction.


### PR DESCRIPTION
Thanks for writing, I really enjoy it!

Question about atomic phases and foreign state mutations. 

The article says:

> An atomic phase is a set of local state mutations that occur in transactions **between** foreign state mutations. 

and then:

> **Every** foreign state mutation gets its own atomic phase.

Do I miss something?

Stripe supports Idempotency-Key anyway so aren't we safe if we die before advancing state machine? 

Regarding wrapping foreign calls in general - if say network isn't good and HTTP request takes 60 seconds we are blocking DB connections for at least 60 seconds too. Doesn't sound ok to me.