### PR TITLE
Optionally run photos through mozjpeg when resizing

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -4,5 +4,6 @@ export BLACK_SWAN_DATABASE_URL="postgres://localhost/black-swan-development?sslm
 export DRAFTS=true
 export CLOUDFRONT_ID=E2D97SPIHRBCUA
 export LOCAL_FONTS=true
+export MOZJPEG_BIN=/usr/local/opt/mozjpeg/bin/cjpeg
 export PORT=5002
 export SORG_ENV=development

--- a/main.go
+++ b/main.go
@@ -156,6 +156,11 @@ type Conf struct {
 	// when using the `passages` command.
 	MailgunAPIKey string `env:"MAILGUN_API_KEY"`
 
+	// MozJPEGBin is the location of the `cjpeg` binary that ships with the
+	// mozjpeg project (a JPG optimizer). If configured, Sorg will put photos
+	// through an optimization pass after resizing them.
+	MozJPEGBin string `env:"MOZJPEG_BIN"`
+
 	// NumAtomEntries is the number of entries to put in Atom feeds.
 	NumAtomEntries int `env:"NUM_ATOM_ENTRIES,default=20"`
 


### PR DESCRIPTION
Allows `MOZJPEG_BIN` to be configured to run resized photos through
mozjpeg for an optimization pass as resizing is being performed.