### PR TITLE
Use modern ImageMagick

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -4,6 +4,7 @@ export BLACK_SWAN_DATABASE_URL="postgres://localhost/black-swan-development?sslm
 export DRAFTS=true
 export CLOUDFRONT_ID=E2D97SPIHRBCUA
 export LOCAL_FONTS=true
+export MAGICK_BIN=/usr/local/opt/imagemagick/bin/magick
 export MOZJPEG_BIN=/usr/local/opt/mozjpeg/bin/cjpeg
 export PORT=5002
 export SORG_ENV=development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,11 @@ jobs:
       - name: "Go: Test"
         run: make test
         env:
+          # GitHub basically makes it fucking impossible to use any kind of
+          # $HOME variable here for reasons that are far beyond me. Eventually
+          # just gave up and hard-coded `/home/runner`.
           MAGICK_BIN: /home/runner/imagemagick/bin/magick
+
           MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
           PGHOST: localhost
           PGPORT: ${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,19 @@ jobs:
         # tooling.
         run: sudo apt-get install awscli postgresql-client
 
+      - name: Cache ImageMagick
+        id: cache-imagemagick
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.HOME }}/imagemagick
+          key: ${{ runner.os }}-imagemagick
+
       # The copy of ImageMagick we could get from apt-get is ancient and
       # doesn't handle niceties like `.heic` files, so here we get the binary
       # release directly. When Ubuntu is upgraded at some point in the
       # probably-distant future, we can probably get rid of this.
       - name: Install ImageMagick
+        if: steps.cache-imagemagick.outputs.cache-hit != 'true'
         run: |
           mkdir -p $HOME/imagemagick/bin/
           curl -L -o $HOME/imagemagick/bin/magick https://imagemagick.org/download/binaries/magick

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       CLOUDFRONT_ID: E2D97SPIHRBCUA
       GOOGLE_ANALYTICS_ID: UA-47798518-1
-      MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
 
     services:
       postgres:
@@ -42,10 +41,20 @@ jobs:
       - name: Install tooling from Apt
         # Postgres runs in a container, but we also need the client-side
         # tooling.
-        run: sudo apt-get install awscli imagemagick graphicsmagick postgresql-client
+        run: sudo apt-get install awscli postgresql-client
+
+      # The copy of ImageMagick we could get from apt-get is ancient and
+      # doesn't handle niceties like `.heic` files, so here we get the binary
+      # release directly. When Ubuntu is upgraded at some point in the
+      # probably-distant future, we can probably get rid of this.
+      - name: Install ImageMagick
+        run: |
+          mkdir -p $HOME/imagemagick/bin/
+          curl -L -o $HOME/imagemagick/bin/magick https://imagemagick.org/download/binaries/magick
+          chmod +x $HOME/imagemagick/bin/magick
 
       # Uses an artifact built by: https://github.com/brandur/mozjpeg-builder
-      - name: Install mozjpeg
+      - name: Install MozJPEG
         run: |
           aws s3 cp s3://mozjpeg-brandur/mozjpeg_master_amd64.deb .
           sudo dpkg -i mozjpeg_master_amd64.deb
@@ -84,6 +93,8 @@ jobs:
       - name: "Go: Test"
         run: make test
         env:
+          MAGICK_BIN: /home/runner/imagemagick/bin/magick
+          MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
           PGHOST: localhost
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           PGUSER: postgres
@@ -131,12 +142,16 @@ jobs:
         env:
           BLACK_SWAN_DATABASE_URL: ${{ secrets.BlackSwanDatabaseURL }}
           DRAFTS: true
+          MAGICK_BIN: /home/runner/imagemagick/bin/magick
+          MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
           TARGET_DIR: ./public-dev
 
       - name: "Build: Production"
         run: make build
         env:
           BLACK_SWAN_DATABASE_URL: ${{ secrets.BlackSwanDatabaseURL }}
+          MAGICK_BIN: /home/runner/imagemagick/bin/magick
+          MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
 
       - name: "Deploy: Development"
         run: make deploy

--- a/build.go
+++ b/build.go
@@ -2270,11 +2270,15 @@ func renderTwitter(c *modulir.Context, db *sql.DB) (bool, error) {
 }
 
 func resizeImage(c *modulir.Context, source, target string, width int) error {
+	if conf.MagickBin == "" {
+		return fmt.Errorf("MAGICK_BIN must be configured for image resizing")
+	}
+
 	var resizeErrOut bytes.Buffer
 	var optimizeErrOut bytes.Buffer
 
 	resizeArgs := []string{
-		"gm",
+		conf.MagickBin,
 		"convert",
 		source,
 		"-auto-orient",

--- a/build_test.go
+++ b/build_test.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/joeshaw/envdecode"
 	assert "github.com/stretchr/testify/require"
 )
+
+func init() {
+	if err := envdecode.Decode(&conf); err != nil {
+		fmt.Fprintf(os.Stderr, "Error decoding conf from env: %v", err)
+		os.Exit(1)
+	}
+}
 
 func TestResizeImage(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "resized_image")

--- a/main.go
+++ b/main.go
@@ -156,6 +156,10 @@ type Conf struct {
 	// when using the `passages` command.
 	MailgunAPIKey string `env:"MAILGUN_API_KEY"`
 
+	// MagickBin is the location of the `magick` binary that ships with the
+	// ImageMagick project (an image manipulation utility).
+	MagickBin string `env:"MAGICK_BIN"`
+
 	// MozJPEGBin is the location of the `cjpeg` binary that ships with the
 	// mozjpeg project (a JPG optimizer). If configured, Sorg will put photos
 	// through an optimization pass after resizing them.


### PR DESCRIPTION
Retrieves a modern version of ImageMagick directly from the source
(instead of relying on the ancient `apt-get` version).