### PR TITLE
Use system installed `awscli`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install tooling from Apt
         # Postgres runs in a container, but we also need the client-side
         # tooling.
-        run: sudo apt-get install awscli postgresql-client
+        run: sudo apt-get install postgresql-client
 
       - name: Cache ImageMagick
         id: cache-imagemagick


### PR DESCRIPTION
According to these docs, `awscli` is already installed on Ubuntu, so
stop installing it via apt:

https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md