### PR TITLE
Don't bother installing psql in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,6 @@ jobs:
           curl -O https://mozjpeg-brandur.s3.us-east-1.amazonaws.com/mozjpeg_master_amd64.deb
           sudo dpkg -i mozjpeg_master_amd64.deb
 
-      # Postgres runs in a container, but we also need the client-side
-      # tooling to interact with it.
-      - name: Install Postgres client tooling
-        run: sudo apt-get install postgresql-client
-
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Don't bother installing psql in CI because it's already provisioned on
the GitHub Actions build image according to:

https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md

This should save ~5 seconds on the build.