### PR TITLE
Add Atom feeds for Nanoglyphs and Passages

### DIFF
--- a/layouts/nanoglyphs.ace
+++ b/layouts/nanoglyphs.ace
@@ -7,6 +7,8 @@ html lang="en"
     meta content="text/html; charset=utf-8" http-equiv="Content-Type"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
 
+    link href="/nanoglyphs.atom" rel="alternate" title="Nanoglyph - brandur.org" type="application/atom+xml"
+
     {{if not .InEmail}}
       link rel="shortcut icon" sizes="152x152" href="/assets/images/favicon/{{.FavIcon}}"
 

--- a/layouts/passages.ace
+++ b/layouts/passages.ace
@@ -7,6 +7,8 @@ html lang="en"
     meta content="text/html; charset=utf-8" http-equiv="Content-Type"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
 
+    link href="/passages.atom" rel="alternate" title="Passages & Glass - brandur.org" type="application/atom+xml"
+
     {{if not .InEmail}}
       link rel="shortcut icon" sizes="152x152" href="/assets/images/favicon/{{.FavIcon}}"
 


### PR DESCRIPTION
Add Atom feeds for an alternate (and luckily, equally open) way to consume newsletter content.