### PR TITLE
Start linting with `golangci-lint` + `xerrors`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - forbidigo
+    - gci
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - '^errors\.Wrap$'
+      - '^errors\.Wrapf$'
+      - '^fmt\.Errorf$'
+  gci:
+    local-prefixes: github.com/brandur

--- a/go.mod
+++ b/go.mod
@@ -35,5 +35,6 @@ require (
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/mailgun/mailgun-go.v1 v1.1.1
 )

--- a/main.go
+++ b/main.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brandur/modulir"
-	"github.com/brandur/modulir/modules/mimage"
-	"github.com/brandur/sorg/modules/scommon"
 	"github.com/joeshaw/envdecode"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/brandur/modulir"
+	"github.com/brandur/modulir/modules/mimage"
+	"github.com/brandur/sorg/modules/scommon"
 )
 
 //////////////////////////////////////////////////////////////////////////////

--- a/modules/sassets/sassets.go
+++ b/modules/sassets/sassets.go
@@ -1,14 +1,15 @@
 package sassets
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/yosssi/gcss"
+	"golang.org/x/xerrors"
+
 	"github.com/brandur/modulir"
 	"github.com/brandur/modulir/modules/mfile"
-	"github.com/yosssi/gcss"
 )
 
 // CompileJavascripts compiles a set of JS files into a single large file by
@@ -35,8 +36,8 @@ func CompileJavascripts(c *modulir.Context, inPath, outPath string) error {
 			return err
 		}
 
-		outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
-		outFile.WriteString("(function() {\n\n")
+		_, _ = outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
+		_, _ = outFile.WriteString("(function() {\n\n")
 
 		// Ignore non-JS files in the directory (I have a README in there)
 		if filepath.Ext(source) == ".js" {
@@ -46,8 +47,8 @@ func CompileJavascripts(c *modulir.Context, inPath, outPath string) error {
 			}
 		}
 
-		outFile.WriteString("\n\n")
-		outFile.WriteString("}).call(this);\n\n")
+		_, _ = outFile.WriteString("\n\n")
+		_, _ = outFile.WriteString("}).call(this);\n\n")
 	}
 
 	return nil
@@ -80,12 +81,12 @@ func CompileStylesheets(c *modulir.Context, inPath, outPath string) error {
 			return err
 		}
 
-		outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
+		_, _ = outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
 
 		if filepath.Ext(source) == ".sass" {
 			_, err := gcss.Compile(outFile, inFile)
 			if err != nil {
-				return fmt.Errorf("Error compiling '%v': %v", source, err)
+				return xerrors.Errorf("error compiling '%v': %w", source, err)
 			}
 		} else {
 			_, err := io.Copy(outFile, inFile)
@@ -94,7 +95,7 @@ func CompileStylesheets(c *modulir.Context, inPath, outPath string) error {
 			}
 		}
 
-		outFile.WriteString("\n\n")
+		_, _ = outFile.WriteString("\n\n")
 	}
 
 	return nil

--- a/modules/sassets/sassets_test.go
+++ b/modules/sassets/sassets_test.go
@@ -4,12 +4,14 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/brandur/sorg/modules/stesting"
 	assert "github.com/stretchr/testify/require"
+
+	"github.com/brandur/sorg/modules/stesting"
 )
 
 func TestCompileJavascripts(t *testing.T) {
 	dir, err := ioutil.TempDir("", "javascripts")
+	assert.NoError(t, err)
 
 	file0 := dir + "/.hidden"
 	file1 := dir + "/file1.js"
@@ -66,6 +68,7 @@ function() { return "file3" }
 
 func TestCompileStylesheets(t *testing.T) {
 	dir, err := ioutil.TempDir("", "stylesheets")
+	assert.NoError(t, err)
 
 	file0 := dir + "/.hidden"
 	file1 := dir + "/file1.sass"

--- a/modules/snewsletter/snewsletter.go
+++ b/modules/snewsletter/snewsletter.go
@@ -1,10 +1,11 @@
 package snewsletter
 
 import (
-	"fmt"
 	"path"
 	"strings"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	"github.com/brandur/modulir"
 	"github.com/brandur/modulir/modules/mmarkdownext"
@@ -75,18 +76,18 @@ func (p *Issue) validate(source string) error {
 		p.ImageOrientation = ImageOrientationLandscape
 	}
 	if p.ImageOrientation != ImageOrientationLandscape && p.ImageOrientation != ImageOrientationPortrait {
-		return fmt.Errorf("Unsupported image orientation for issue: %v (must be '%v' or '%v')",
+		return xerrors.Errorf("unsupported image orientation for issue: %v (must be '%v' or '%v')",
 			source,
 			ImageOrientationLandscape,
 			ImageOrientationPortrait)
 	}
 
 	if p.Title == "" {
-		return fmt.Errorf("No title for issue: %v", source)
+		return xerrors.Errorf("no title for issue: %v", source)
 	}
 
 	if p.PublishedAt == nil {
-		return fmt.Errorf("No publish date for issue: %v", source)
+		return xerrors.Errorf("no publish date for issue: %v", source)
 	}
 
 	return nil
@@ -112,7 +113,7 @@ func Render(c *modulir.Context, dir, name, absoluteURL string, email bool) (*Iss
 
 	slugParts := strings.Split(issue.Slug, "-")
 	if len(slugParts) < 2 {
-		return nil, fmt.Errorf("Expected slug to contain issue number: %v",
+		return nil, xerrors.Errorf("expected slug to contain issue number: %v",
 			issue.Slug)
 	}
 	issue.Number = slugParts[0]

--- a/modules/squantified/squantified.go
+++ b/modules/squantified/squantified.go
@@ -12,11 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/yosssi/ace"
+
 	"github.com/brandur/modulir"
 	"github.com/brandur/modulir/modules/mace"
 	"github.com/brandur/modulir/modules/mtoml"
 	"github.com/brandur/sorg/modules/scommon"
-	"github.com/yosssi/ace"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -527,7 +528,7 @@ func getRunsByYearData(db *sql.DB) ([]string, []float64, error) {
 		ORDER BY year DESC
 	`)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error selecting runs by year: %v", err)
+		return nil, nil, xerrors.Errorf("error selecting runs by year: %w", err)
 	}
 	defer rows.Close()
 
@@ -540,7 +541,7 @@ func getRunsByYearData(db *sql.DB) ([]string, []float64, error) {
 			&distance,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error scanning runs by year: %v", err)
+			return nil, nil, xerrors.Errorf("error scanning runs by year: %w", err)
 		}
 
 		byYearXYears = append(byYearXYears, year)
@@ -548,7 +549,7 @@ func getRunsByYearData(db *sql.DB) ([]string, []float64, error) {
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error iterating runs by year: %v", err)
+		return nil, nil, xerrors.Errorf("Error iterating runs by year: %w", err)
 	}
 
 	return byYearXYears, byYearYDistances, nil
@@ -600,7 +601,7 @@ func getRunsLastYearData(db *sql.DB) ([]string, []float64, error) {
 			LEFT JOIN runs_days rd ON d.day = rd.day
 	`)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error selecting last year runs: %v", err)
+		return nil, nil, xerrors.Errorf("error selecting last year runs: %w", err)
 	}
 	defer rows.Close()
 
@@ -613,7 +614,7 @@ func getRunsLastYearData(db *sql.DB) ([]string, []float64, error) {
 			&distance,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error scanning last year runs: %v", err)
+			return nil, nil, xerrors.Errorf("error scanning last year runs: %w", err)
 		}
 
 		lastYearXDays = append(lastYearXDays, day)
@@ -621,7 +622,7 @@ func getRunsLastYearData(db *sql.DB) ([]string, []float64, error) {
 	}
 	err = rows.Err()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error iterating last year runs: %v", err)
+		return nil, nil, xerrors.Errorf("error iterating last year runs: %w", err)
 	}
 
 	return lastYearXDays, lastYearYDistances, nil

--- a/modules/stalks/stalks.go
+++ b/modules/stalks/stalks.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/brandur/modulir"
 	"github.com/brandur/modulir/modules/mmarkdownext"
 	"github.com/brandur/modulir/modules/mtoml"
@@ -87,19 +89,19 @@ func (t *Talk) PublishingInfo() map[string]string {
 
 func (t *Talk) validate(source string) error {
 	if t.Event == "" {
-		return fmt.Errorf("No event for talk: %v", source)
+		return xerrors.Errorf("no event for talk: %v", source)
 	}
 
 	if t.Location == "" {
-		return fmt.Errorf("No location for talk: %v", source)
+		return xerrors.Errorf("no location for talk: %v", source)
 	}
 
 	if t.Title == "" {
-		return fmt.Errorf("No title for talk: %v", source)
+		return xerrors.Errorf("no title for talk: %v", source)
 	}
 
 	if t.PublishedAt == nil {
-		return fmt.Errorf("No publish date for talk: %v", source)
+		return xerrors.Errorf("no publish date for talk: %v", source)
 	}
 
 	return nil
@@ -144,7 +146,7 @@ func Render(c *modulir.Context, contentDir, dir, name string) (*Talk, error) {
 	}
 
 	if talk.Intro == "" {
-		return nil, fmt.Errorf("No intro for talk: %v (provide one as the presenter notes of the first slide)", source)
+		return nil, xerrors.Errorf("no intro for talk: %v (provide one as the presenter notes of the first slide)", source)
 	}
 
 	return &talk, nil
@@ -214,7 +216,7 @@ func splitAndRenderSlides(contentDir string, talk *Talk, content string) ([]*Sli
 		} else if fileExists(path.Join(talksImageDir, talk.Slug, jpgName)) {
 			slide.ImagePath = fmt.Sprintf("%s/%s/%s", talksAssetPath, talk.Slug, jpgName)
 		} else {
-			return nil, fmt.Errorf("Couldn't find any image asset for slide %s / %s at %s",
+			return nil, xerrors.Errorf("couldn't find any image asset for slide %s / %s at %s",
 				pngName, jpgName, path.Join(talksImageDir, talk.Slug))
 		}
 	}

--- a/modules/stalks/stalks_test.go
+++ b/modules/stalks/stalks_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brandur/sorg/modules/stesting"
 	assert "github.com/stretchr/testify/require"
+
+	"github.com/brandur/sorg/modules/stesting"
 )
 
 func TestRender(t *testing.T) {

--- a/modules/stemplate/stemplate.go
+++ b/modules/stemplate/stemplate.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brandur/modulir/modules/mtemplate"
 	"github.com/yosssi/ace"
+
+	"github.com/brandur/modulir/modules/mtemplate"
 )
 
 // FuncMap is a set of helper functions to make available in templates for the

--- a/modules/stemplate/stemplate_test.go
+++ b/modules/stemplate/stemplate_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/brandur/sorg/modules/stesting"
 	assert "github.com/stretchr/testify/require"
+
+	_ "github.com/brandur/sorg/modules/stesting"
 )
 
 var testTime time.Time
@@ -113,12 +114,4 @@ func TestToStars(t *testing.T) {
 	assert.Equal(t, "", toStars(0))
 	assert.Equal(t, "★ ", toStars(1))
 	assert.Equal(t, "★ ★ ★ ★ ★ ", toStars(5))
-}
-
-func mustParseDuration(s string) time.Duration {
-	d, err := time.ParseDuration(s)
-	if err != nil {
-		panic(err)
-	}
-	return d
 }

--- a/modules/stoc/stoc.go
+++ b/modules/stoc/stoc.go
@@ -2,11 +2,11 @@ package stoc
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"strconv"
 
 	"golang.org/x/net/html"
+	"golang.org/x/xerrors"
 )
 
 type header struct {
@@ -25,7 +25,7 @@ func Render(content string) (string, error) {
 	for _, match := range matches {
 		level, err := strconv.Atoi(match[1])
 		if err != nil {
-			return "", fmt.Errorf("Couldn't extract header level: %v", err.Error())
+			return "", xerrors.Errorf("couldn't extract header level: %v", err.Error())
 		}
 
 		headers = append(headers, &header{level, "#" + match[2], match[4]})
@@ -98,7 +98,6 @@ func buildTree(headers []*header) *html.Node {
 		if needNewListNode {
 			listItemNode = &html.Node{Data: "li", Type: html.ElementNode}
 			listNode.AppendChild(listItemNode)
-			needNewListNode = false
 		}
 
 		contentNode := &html.Node{Data: header.title, Type: html.TextNode}
@@ -115,7 +114,7 @@ func buildTree(headers []*header) *html.Node {
 
 		needNewListNode = true
 
-		//log.Debugf("TOC: Inserted header: %v", header.id)
+		// log.Debugf("TOC: Inserted header: %v", header.id)
 	}
 
 	return topNode

--- a/scripts/set_image_mtimes.go
+++ b/scripts/set_image_mtimes.go
@@ -45,7 +45,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -142,7 +142,7 @@ func batchImages(allImages []string) [][]string {
 func getAllImages() ([]string, error) {
 	out, err := runCommand("git", "ls-tree", "-r", "--name-only", "HEAD", imagePath)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error getting images with `git ls-tree`")
+		return nil, xerrors.Errorf("error getting images with `git ls-tree`: %w", err)
 	}
 
 	return strings.Split(out, "\n"), nil
@@ -153,7 +153,7 @@ func getAllImages() ([]string, error) {
 func getLastCommitTime(path string) (*time.Time, error) {
 	out, err := runCommand("git", "log", "--max-count=1", `--pretty=format:%aI`, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error getting commit time for: %s", path)
+		return nil, xerrors.Errorf("error getting commit time for '%s': %w", path, err)
 	}
 
 	lastCommitTime, err := time.Parse("2006-01-02T15:04:05-07:00", out)
@@ -174,7 +174,7 @@ func runCommand(name string, arg ...string) (string, error) {
 
 	out, err := cmd.Output()
 	if err != nil {
-		return "", errors.Wrapf(err, "Error executing command: %s", name)
+		return "", xerrors.Errorf("error executing command '%s': %w", name, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
Introduces a more hard line linter with `golangci-lint`. Most linters
are still disabled, but this gets some of the more important ones
enabled.

Also switch to use `xerrors` everywhere.