### PR TITLE
Enable strict linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,25 @@
 linters:
-  enable:
-    - forbidigo
-    - gci
+  disable:
+    - cyclop
+    - dupl
+    - exhaustivestruct
+    - forcetypeassert
+    - funlen
+    - gochecknoinits
+    - gochecknoglobals
+    - gocognit
+    - gocyclo
+    - godox
+    - golint
+    - gomnd
+    - interfacer
+    - maligned
+    - nlreturn
+    - paralleltest
+    - scopelint
+    - testpackage
+    - wsl
+  enable-all: true
 
 linters-settings:
   forbidigo:
@@ -11,3 +29,15 @@ linters-settings:
       - '^fmt\.Errorf$'
   gci:
     local-prefixes: github.com/brandur
+
+  gocritic:
+    disabled-checks:
+      - commentFormatting
+
+  gosec:
+    excludes:
+      - G203
+
+  wrapcheck:
+    ignorePackageGlobs:
+      - github.com/brandur/*

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 //////////////////////////////////////////////////////////////////////////////
 
 func main() {
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "sorg",
 		Short: "Sorg is a static site generator",
 		Long: strings.TrimSpace(`

--- a/modules/sassets/sassets.go
+++ b/modules/sassets/sassets.go
@@ -26,14 +26,14 @@ func CompileJavascripts(c *modulir.Context, inPath, outPath string) error {
 
 	outFile, err := os.Create(outPath)
 	if err != nil {
-		return err
+		return xerrors.Errorf("error creating file '%s': %w", outPath, err)
 	}
 	defer outFile.Close()
 
 	for _, source := range sources {
 		inFile, err := os.Open(source)
 		if err != nil {
-			return err
+			return xerrors.Errorf("error opening file '%s': %w", source, err)
 		}
 
 		_, _ = outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
@@ -43,7 +43,7 @@ func CompileJavascripts(c *modulir.Context, inPath, outPath string) error {
 		if filepath.Ext(source) == ".js" {
 			_, err = io.Copy(outFile, inFile)
 			if err != nil {
-				return err
+				return xerrors.Errorf("error copying '%s' to '%s': %w", source, outPath, err)
 			}
 		}
 
@@ -71,14 +71,14 @@ func CompileStylesheets(c *modulir.Context, inPath, outPath string) error {
 
 	outFile, err := os.Create(outPath)
 	if err != nil {
-		return err
+		return xerrors.Errorf("error creating file '%s': %w", outPath, err)
 	}
 	defer outFile.Close()
 
 	for _, source := range sources {
 		inFile, err := os.Open(source)
 		if err != nil {
-			return err
+			return xerrors.Errorf("error opening file '%s': %w", source, err)
 		}
 
 		_, _ = outFile.WriteString("/* " + filepath.Base(source) + " */\n\n")
@@ -91,7 +91,7 @@ func CompileStylesheets(c *modulir.Context, inPath, outPath string) error {
 		} else {
 			_, err := io.Copy(outFile, inFile)
 			if err != nil {
-				return err
+				return xerrors.Errorf("error copying '%s' to '%s': %w", source, outPath, err)
 			}
 		}
 

--- a/modules/sassets/sassets_test.go
+++ b/modules/sassets/sassets_test.go
@@ -20,16 +20,16 @@ func TestCompileJavascripts(t *testing.T) {
 	out := dir + "/app.js"
 
 	// This file is hidden and doesn't show up in output.
-	err = ioutil.WriteFile(file0, []byte(`hidden`), 0755)
+	err = ioutil.WriteFile(file0, []byte(`hidden`), 0o600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file1, []byte(`function() { return "file1" }`), 0755)
+	err = ioutil.WriteFile(file1, []byte(`function() { return "file1" }`), 0o600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file2, []byte(`function() { return "file2" }`), 0755)
+	err = ioutil.WriteFile(file2, []byte(`function() { return "file2" }`), 0o600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file3, []byte(`function() { return "file3" }`), 0755)
+	err = ioutil.WriteFile(file3, []byte(`function() { return "file3" }`), 0o600)
 	assert.NoError(t, err)
 
 	err = CompileJavascripts(stesting.NewContext(), dir, out)
@@ -77,18 +77,18 @@ func TestCompileStylesheets(t *testing.T) {
 	out := dir + "/app.css"
 
 	// This file is hidden and doesn't show up in output.
-	err = ioutil.WriteFile(file0, []byte("hidden"), 0755)
+	err = ioutil.WriteFile(file0, []byte("hidden"), 0o600)
 	assert.NoError(t, err)
 
 	// The syntax of the first and second files is GCSS and the third is in
 	// CSS.
-	err = ioutil.WriteFile(file1, []byte("p\n  margin: 10px"), 0755)
+	err = ioutil.WriteFile(file1, []byte("p\n  margin: 10px"), 0o600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file2, []byte("p\n  padding: 10px"), 0755)
+	err = ioutil.WriteFile(file2, []byte("p\n  padding: 10px"), 0o600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(file3, []byte("p {\n  border: 10px;\n}"), 0755)
+	err = ioutil.WriteFile(file3, []byte("p {\n  border: 10px;\n}"), 0o600)
 	assert.NoError(t, err)
 
 	err = CompileStylesheets(stesting.NewContext(), dir, out)

--- a/modules/squantified/squantified_test.go
+++ b/modules/squantified/squantified_test.go
@@ -65,7 +65,8 @@ end`})),
 
 	// long link
 	assert.Equal(t,
-		`<a href="https://example.com/path/to/more/great/stuff/and/this/is/even/longer/now" rel="nofollow">example.com/path/to/more/great/stuff/and/this/is/e&hellip;</a>`,
+		`<a href="https://example.com/path/to/more/great/stuff/and/this/is/even/longer/now" `+
+			`rel="nofollow">example.com/path/to/more/great/stuff/and/this/is/e&hellip;</a>`,
 		string(tweetTextToHTML(&Tweet{Text: `https://example.com/path/to/more/great/stuff/and/this/is/even/longer/now`})),
 	)
 

--- a/modules/stalks/stalks.go
+++ b/modules/stalks/stalks.go
@@ -120,7 +120,7 @@ func Render(c *modulir.Context, contentDir, dir, name string) (*Talk, error) {
 	talk.Draft = strings.Contains(filepath.Base(dir), "drafts")
 
 	// TODO: Replace with extractSlug brought into scommon
-	talk.Slug = strings.Replace(name, ".md", "", -1)
+	talk.Slug = strings.ReplaceAll(name, ".md", "")
 
 	err = talk.validate(source)
 	if err != nil {
@@ -211,11 +211,12 @@ func splitAndRenderSlides(contentDir string, talk *Talk, content string) ([]*Sli
 		pngName := fmt.Sprintf("%s.%s.png", talk.Slug, slide.Number)
 		jpgName := fmt.Sprintf("%s.%s.jpg", talk.Slug, slide.Number)
 
-		if fileExists(path.Join(talksImageDir, talk.Slug, pngName)) {
+		switch {
+		case fileExists(path.Join(talksImageDir, talk.Slug, pngName)):
 			slide.ImagePath = fmt.Sprintf("%s/%s/%s", talksAssetPath, talk.Slug, pngName)
-		} else if fileExists(path.Join(talksImageDir, talk.Slug, jpgName)) {
+		case fileExists(path.Join(talksImageDir, talk.Slug, jpgName)):
 			slide.ImagePath = fmt.Sprintf("%s/%s/%s", talksAssetPath, talk.Slug, jpgName)
-		} else {
+		default:
 			return nil, xerrors.Errorf("couldn't find any image asset for slide %s / %s at %s",
 				pngName, jpgName, path.Join(talksImageDir, talk.Slug))
 		}

--- a/modules/stemplate/stemplate.go
+++ b/modules/stemplate/stemplate.go
@@ -101,7 +101,7 @@ func lazyRetinaImageLightboxMaybe(index int, path, slug string, portrait, lightb
 //
 // https://github.com/brandur/sorg/pull/60
 func toNonBreakingWhitespace(str string) string {
-	return strings.Replace(str, " ", " ", -1)
+	return strings.ReplaceAll(str, " ", " ")
 }
 
 func inKM(m float64) float64 {
@@ -130,7 +130,8 @@ func nanoglyphSignup(inEmail bool) template.HTML {
 		panic(err)
 	}
 
-	subscribeText := `<p id="subscribe-encouragement">This post was originally broadcast in email form. Can I interest you in seeing more like it? <em>Nanoglyph</em> is never sent more than once a week.</p>`
+	subscribeText := `<p id="subscribe-encouragement">This post was originally broadcast in email form. ` +
+		`Can I interest you in seeing more like it? <em>Nanoglyph</em> is never sent more than once a week.</p>`
 
 	writer.Flush()
 	return template.HTML(subscribeText + b.String())
@@ -174,13 +175,14 @@ func numberWithDelimiter(sep rune, n int) string {
 // "clock" time like 4:52 which translates to "4 minutes and 52 seconds" per
 // kilometer.
 func pace(distance float64, duration time.Duration) string {
-	speed := float64(duration.Seconds()) / inKM(distance)
+	speed := duration.Seconds() / inKM(distance)
 	min := int64(speed / 60.0)
 	sec := int64(speed) % 60
 	return fmt.Sprintf("%v:%02d", min, sec)
 }
 
 func randIntn(bound int) int {
+	// nolint:gosec
 	return rand.Intn(bound)
 }
 
@@ -204,7 +206,7 @@ func RetinaImageAlt(src, alt string) template.HTML {
 	)
 }
 
-// There is no "round" function built into Go :/
+// There is no "round" function built into Go :/.
 func round(f float64) float64 {
 	return math.Floor(f + .5)
 }

--- a/modules/stemplate/stemplate_test.go
+++ b/modules/stemplate/stemplate_test.go
@@ -38,20 +38,25 @@ func TestInKM(t *testing.T) {
 
 func TestLazyRetinaImage(t *testing.T) {
 	assert.Equal(t,
-		`<img class="lazy" src="/assets/images/standin_00.jpg" data-src="/photographs/other/001_large.jpg" data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x">`,
+		`<img class="lazy" src="/assets/images/standin_00.jpg" data-src="/photographs/other/001_large.jpg" `+
+			`data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x">`,
 		lazyRetinaImage(0, "/photographs/other/", "001"),
 	)
 }
 
 func TestLazyRetinaImageLightbox(t *testing.T) {
 	assert.Equal(t,
-		`<a href="/photographs/other/001_large@2x.jpg"><img class="lazy" src="/assets/images/standin_00.jpg" data-src="/photographs/other/001_large.jpg" data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x"></a>`,
+		`<a href="/photographs/other/001_large@2x.jpg">`+
+			`<img class="lazy" src="/assets/images/standin_00.jpg" data-src="/photographs/other/001_large.jpg" `+
+			`data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x"></a>`,
 		lazyRetinaImageLightbox(0, "/photographs/other/", "001", false),
 	)
 
 	// Portrait
 	assert.Equal(t,
-		`<a href="/photographs/other/001_large@2x.jpg"><img class="lazy" src="/assets/images/standin_portrait_00.jpg" data-src="/photographs/other/001_large.jpg" data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x"></a>`,
+		`<a href="/photographs/other/001_large@2x.jpg">`+
+			`<img class="lazy" src="/assets/images/standin_portrait_00.jpg" data-src="/photographs/other/001_large.jpg" `+
+			`data-srcset="/photographs/other/001_large@2x.jpg 2x, /photographs/other/001_large.jpg 1x"></a>`,
 		lazyRetinaImageLightbox(0, "/photographs/other/", "001", true),
 	)
 }
@@ -81,7 +86,7 @@ func TestNumberWithDelimiter(t *testing.T) {
 }
 
 func TestPace(t *testing.T) {
-	d := time.Duration(60 * time.Second)
+	d := 60 * time.Second
 
 	// Easiest case: 1000 m ran in 60 seconds which is 1:00 per km.
 	assert.Equal(t, "1:00", pace(1000.0, d))
@@ -99,7 +104,8 @@ func TestRandIntn(t *testing.T) {
 
 func TestRetinaImageAlt(t *testing.T) {
 	assert.Equal(t,
-		`<img alt="alt text" loading="lazy" src="/photographs/other/001.jpg" srcset="/photographs/other/001@2x.jpg 2x, /photographs/other/001.jpg 1x">`,
+		`<img alt="alt text" loading="lazy" src="/photographs/other/001.jpg" `+
+			`srcset="/photographs/other/001@2x.jpg 2x, /photographs/other/001.jpg 1x">`,
 		string(RetinaImageAlt("/photographs/other/001.jpg", "alt text")),
 	)
 }

--- a/modules/stesting/stesting.go
+++ b/modules/stesting/stesting.go
@@ -49,10 +49,10 @@ func init() {
 	// returns *this* file (`testing.go`), and we can then trace up to the
 	// project's root directory no matter what package is being tested (tests
 	// have their CWD set to the project's path).
+	// nolint:dogsled
 	_, filename, _, _ := runtime.Caller(0)
 	path.Join(path.Dir(filename), "..")
-	err := os.Chdir("../../")
-	if err != nil {
+	if err := os.Chdir("../../"); err != nil {
 		panic(err)
 	}
 }

--- a/modules/stoc/stoc.go
+++ b/modules/stoc/stoc.go
@@ -19,9 +19,8 @@ var headerRegexp = regexp.MustCompile(`<h([0-9]) id="(.*?)">(<a.*?>)?(.*?)(</a>)
 
 // Render renders the table of contents as an HTML string.
 func Render(content string) (string, error) {
-	var headers []*header
-
 	matches := headerRegexp.FindAllStringSubmatch(content, -1)
+	headers := make([]*header, 0, len(matches))
 	for _, match := range matches {
 		level, err := strconv.Atoi(match[1])
 		if err != nil {
@@ -62,7 +61,7 @@ func buildTree(headers []*header) *html.Node {
 	var level int
 	if len(headers) > 0 {
 		level = headers[0].level
-		//log.Debugf("TOC: Starting level: %v", level)
+		// log.Debugf("TOC: Starting level: %v", level)
 	}
 
 	for _, header := range headers {
@@ -74,7 +73,7 @@ func buildTree(headers []*header) *html.Node {
 				listNode = &html.Node{Data: "ol", Type: html.ElementNode}
 				listItemNode.AppendChild(listNode)
 
-				//log.Debugf("TOC: --> Indenting once to level: %v", header.level)
+				// log.Debugf("TOC: --> Indenting once to level: %v", header.level)
 			}
 
 			needNewListNode = true
@@ -89,7 +88,7 @@ func buildTree(headers []*header) *html.Node {
 				listItemNode = listNode.Parent
 				listNode = listItemNode.Parent
 
-				//log.Debugf("TOC: --< Dedenting once to level: %v", header.level)
+				// log.Debugf("TOC: --< Dedenting once to level: %v", header.level)
 			}
 
 			level = header.level
@@ -122,9 +121,8 @@ func buildTree(headers []*header) *html.Node {
 
 func renderTree(node *html.Node) (string, error) {
 	var b bytes.Buffer
-	err := html.Render(&b, node)
-	if err != nil {
-		return "", err
+	if err := html.Render(&b, node); err != nil {
+		return "", xerrors.Errorf("error rendering HTML: %w", err)
 	}
 
 	return b.String(), nil

--- a/modules/stoc/stoc_test.go
+++ b/modules/stoc/stoc_test.go
@@ -178,7 +178,8 @@ func TestRender(t *testing.T) {
 
 		Content.
 	`
-	expected := `<ol><li><a href="#h-a">Heading A</a><ol><li><a href="#h-b">Heading B</a></li></ol></li><li><a href="#h-c">Heading C</a></li></ol>`
+	expected := `<ol><li><a href="#h-a">Heading A</a><ol><li><a href="#h-b">Heading B</a></li>` +
+		`</ol></li><li><a href="#h-c">Heading C</a></li></ol>`
 
 	rendered, err := Render(content)
 	assert.NoError(t, err)

--- a/scripts/set_image_mtimes.go
+++ b/scripts/set_image_mtimes.go
@@ -158,7 +158,7 @@ func getLastCommitTime(path string) (*time.Time, error) {
 
 	lastCommitTime, err := time.Parse("2006-01-02T15:04:05-07:00", out)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("error parsing time '%s': %w", out, err)
 	}
 
 	return &lastCommitTime, nil

--- a/send.go
+++ b/send.go
@@ -127,7 +127,6 @@ func renderAndSend(c *modulir.Context, source string, live, staging bool) error 
 	if conf.MailgunAPIKey == "" {
 		return xerrors.Errorf(
 			"MAILGUN_API_KEY must be configured in the environment")
-
 	}
 
 	newsletterInfo, draft := matchNewsletter(source)
@@ -167,15 +166,16 @@ func renderAndSend(c *modulir.Context, source string, live, staging bool) error 
 
 	html, err := inliner.Inline(b.String())
 	if err != nil {
-		return err
+		return xerrors.Errorf("error inlining CSS: %w", err)
 	}
 
 	var recipient string
-	if live {
+	switch {
+	case live:
 		recipient = newsletterInfo.MailAddress
-	} else if staging {
+	case staging:
 		recipient = newsletterInfo.MailAddressStaging
-	} else {
+	default:
 		recipient = testAddress
 	}
 
@@ -195,7 +195,7 @@ func renderAndSend(c *modulir.Context, source string, live, staging bool) error 
 
 	resp, _, err := mg.Send(message)
 	if err != nil {
-		return err
+		return xerrors.Errorf("error sending email: %w", err)
 	}
 
 	c.Log.Infof(`Sent to: %s (response: "%s")`, recipient, resp)


### PR DESCRIPTION
Enables all `golangci-lint` linters except for the really obnoxious ones.