### PR TITLE
Remove extra "to stay" in "2020 Light" sequence

### DIFF
--- a/content/sequences/2020-light/_meta.toml
+++ b/content/sequences/2020-light/_meta.toml
@@ -1,7 +1,7 @@
 title = "2020 Light"
 #background_image_url = "https://www.dropbox.com/s/16j6qrfsr7dxhjf/L1070618-adjusted.jpg?dl=1"
 description = """\
-The world of 2020 is small. Not only has globe trotting come to a sudden, ignominous end, but much of the world was ordered to stay to stay within the confines of their own home. Many of us found suddenly found ourselves as full-time remote workers, and we're the lucky ones. Friends, colleagues, and family were banished to spectral sprites on computer screens.
+The world of 2020 is small. Not only has globe trotting come to a sudden, ignominous end, but much of the world was ordered to stay within the confines of their own home. Many of us found suddenly found ourselves as full-time remote workers, and we're the lucky ones. Friends, colleagues, and family were banished to spectral sprites on computer screens.
 
 _2020 Light_ is a photography project that involves me shooting close to where I live, in and around San Francisco. I've always felt that my days here were numbered, and along with being a creative outlet to help me stay sane, it'll also serve as a memento for the city after I've gone.
 


### PR DESCRIPTION
There was an extra "to stay" in the introduction of the "2020 Light" sequence