### PR TITLE
Fix typo: "losiness" => "lossiness"

### DIFF
--- a/content/articles/canonical-log-lines.md
+++ b/content/articles/canonical-log-lines.md
@@ -316,7 +316,7 @@ into any tech stack you happen to be using.
     eating into them.
 
 [3] A daemon local to each node buffers messages and sends
-    them off to Kafka in batches (some losiness can be
+    them off to Kafka in batches (some lossiness can be
     tolerated here). We previously used NSQ for the same
     purpose.
 


### PR DESCRIPTION
I saw the typo, and then I saw:

> Did I make a mistake? Please consider sending a pull request.

And I thought that was pretty darn nifty. So here I am.