### PR TITLE
Update logfmt.md with improved python package

### DIFF
--- a/content/articles/logfmt.md
+++ b/content/articles/logfmt.md
@@ -164,7 +164,7 @@ A few projects from already exist to help parse logfmt in various languages:
 * [logfmt for Clojure](https://github.com/tcrayford/logfmt)
 * [logfmt for Go](http://godoc.org/github.com/kr/logfmt)
 * [logfmt for Node.JS](https://github.com/csquared/node-logfmt)
-* [logfmt for Python](https://pypi.python.org/pypi/logfmt/0.1)
+* [logfmt for Python](https://github.com/jteppinette/python-logfmter)
 * [logfmt for Ruby](https://github.com/cyberdelia/logfmt-ruby)
 
 [logrus]: https://github.com/sirupsen/logrus


### PR DESCRIPTION
# What
This change request updates the recommended Python logfmt package in the logfmt blog post.

# Why
The https://github.com/kr/logfmt package is no longer maintained or functional. The package has since passed to a new maintainer, but the package is still unmaintained or functional. The new maintainer now recommends https://github.com/jteppinette/python-logfmter (https://github.com/wlonk/logfmt-python/commit/1ee07cafc315d71fd6b1150bbaeee2de6e732671), a package I recently created to fill this gap.