### PR TITLE
fix: Update the URL to the Crunchy Bridge Idempotency documentation

### DIFF
--- a/content/fragments/idempotency-keys-crunchy.md
+++ b/content/fragments/idempotency-keys-crunchy.md
@@ -6,7 +6,7 @@ title = "Idempotency keys @ Crunchy"
 
 A few months ago I wrote about [the IETF draft for the `Idempotency-Key` header](/fragments/idempotency-key-draft), a way for an API to provide idempotent operation on non-idempotent verbs like `POST` and `PATCH`.
 
-I'd been intending to an `Idempotency-Key` implementation in at work, and finally [got around to it](https://docs.crunchybridge.com/api/idempotency/).
+I'd been intending to an `Idempotency-Key` implementation in at work, and finally [got around to it](https://docs.crunchybridge.com/api-concepts/idempotency/).
 `
 The implementation largely follows what's it in the IETF draft, which itself is largely based off Stripe's original conventions. Similarly to Stripe:
 


### PR DESCRIPTION
I am just fixing the URL to the Crunchy Bridge › API concepts › Idempotency page, which seems to have moved from <https://docs.crunchybridge.com/api/idempotency/> to <https://docs.crunchybridge.com/api-concepts/idempotency/>.