### PR TITLE
Fix footnote linking in sqlc.md

### DIFF
--- a/content/articles/sqlc.md
+++ b/content/articles/sqlc.md
@@ -86,7 +86,7 @@ INSERT INTO authors (
 RETURNING *;
 ```
 
-After running `sqlc generate` [1] (which generates Go code from your SQL definitions), you're now able to run this:
+After running `sqlc generate` (which generates Go code from your SQL definitions) [1], you're now able to run this:
 
 ``` go
 author, err = dbsqlc.New(tx).CreateAuthor(ctx, dbsqlc.CreateAuthor{


### PR DESCRIPTION
The current version does not properly link to the footnote and this PR addresses that.

Although the order of the footnote reference and `(which generates...)` is reversed it's probably still OK. Keeping the order would require a different solution.