### PR TITLE
Break GitHub Actions workflow into separate check and deploy steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,16 @@
 name: sorg CI
 
 env:
+  # Saw build failures, apparently because awscli is trying to determine
+  # region. This is an undocumented env var that disables that check.
+  #
+  # Discovered from: https://github.com/aws/aws-cli/issues/5262#issuecomment-705832151
+  AWS_EC2_METADATA_DISABLED: true
+
+  CONCURRENCY: 10 # reduced because I think I'm running into Dropbox rate problems
+  ENABLE_GOAT_COUNTER: true
   GO_VERSION: 1.19
+  GOOGLE_ANALYTICS_ID: UA-47798518-1
 
 on:
   pull_request:
@@ -11,21 +20,9 @@ on:
     - cron: "0 */3 * * *"
 
 jobs:
-  build:
+  check_and_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    env:
-      # Saw build failures, apparently because awscli is trying to determine
-      # region. This is an undocumented env var that disables that check.
-      #
-      # Discovered from: https://github.com/aws/aws-cli/issues/5262#issuecomment-705832151
-      AWS_EC2_METADATA_DISABLED: true
-
-      CLOUDFRONT_ID: E2D97SPIHRBCUA
-      CONCURRENCY: 10 # reduced because I think I'm running into Dropbox rate problems
-      ENABLE_GOAT_COUNTER: true
-      GOOGLE_ANALYTICS_ID: UA-47798518-1
+    timeout-minutes: 3
 
     steps:
       - name: Install Go
@@ -87,9 +84,6 @@ jobs:
       - name: "Go: Install"
         run: make install
 
-      - name: Fetch latest qself data/
-        run: make data-update
-
       - name: "Go: Test"
         run: make test
         env:
@@ -116,57 +110,7 @@ jobs:
       - name: "Check: Retina assets"
         run: make check-retina
 
-      # Download any markers that have not yet been committed to Git to save
-      # redoing download/resize work.
-      - name: "Download photo markers"
-        run: make photographs-download-markers
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
-        if: github.ref == 'refs/heads/master'
-
-      - name: "Build: Development"
-        run: make build
-        env:
-          DRAFTS: true
-          MAGICK_BIN: /home/runner/imagemagick/bin/magick
-          MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
-          PNGQUANT_BIN: /usr/bin/pngquant
-          TARGET_DIR: ./public-dev
-
-      - name: "Build: Production"
-        run: make build
-        env:
-          MAGICK_BIN: /home/runner/imagemagick/bin/magick
-          MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
-          PNGQUANT_BIN: /usr/bin/pngquant
-
-      - name: "Deploy: Development"
-        run: make deploy
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
-          S3_BUCKET: brandur.org-dev
-          TARGET_DIR: ./public-dev
-        if: github.ref == 'refs/heads/master'
-
-      - name: "Deploy: Production"
-        run: make deploy
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
-          S3_BUCKET: brandur.org
-          TARGET_DIR: ./public
-        if: github.ref == 'refs/heads/master'
-
-      - name: Upload photos
-        run: make photographs-upload
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
-        if: github.ref == 'refs/heads/master'
-
-  check-tailwind:
+  check_tailwind:
     runs-on: ubuntu-latest
     timeout-minutes: 3
 
@@ -192,6 +136,87 @@ jobs:
         run: |
           echo "Please make sure that all Tailwind changes are checked in!"
           git diff --exit-code .
+
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: github.ref == 'refs/heads/master'
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
+      MAGICK_BIN: /home/runner/imagemagick/bin/magick
+      MOZJPEG_BIN: /opt/mozjpeg/bin/cjpeg
+      PNGQUANT_BIN: /usr/bin/pngquant
+
+    needs:
+      - check_and_test
+      - check_tailwind
+      - golangci-lint
+
+    steps:
+      # See notes in check_and_test.
+      - name: Install ImageMagick
+        run: |
+          mkdir -p $HOME/imagemagick/bin/
+          curl --compressed -L -o $HOME/imagemagick/bin/magick https://github.com/brandur/imagemagick-builder/releases/download/master/magick
+          chmod +x $HOME/imagemagick/bin/magick
+
+      - name: ImageMagick format options
+        run: $HOME/imagemagick/bin/magick identify -list format
+
+      # See notes in check_and_test.
+      - name: Install MozJPEG
+        run: |
+          curl --compressed -L -O https://github.com/brandur/mozjpeg-builder/releases/download/master/mozjpeg_amd64.deb
+          sudo dpkg -i mozjpeg_amd64.deb
+
+      # See notes in check_and_test.
+      - name: Install PNGQuant
+        run: sudo apt-get install pngquant
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Go: Install"
+        run: make install
+
+      # Download any markers that have not yet been committed to Git to save
+      # redoing download/resize work.
+      - name: "Download photo markers"
+        run: make photographs-download-markers
+
+      - name: "Download latest qself data/"
+        run: make data-update
+
+      - name: "Build: Development"
+        run: make build
+        env:
+          DRAFTS: true
+          TARGET_DIR: ./public-dev
+
+      - name: "Build: Production"
+        run: make build
+        env:
+          TARGET_DIR: ./public-dev
+
+      - name: "Deploy: Development"
+        run: make deploy
+        env:
+          S3_BUCKET: brandur.org-dev
+          TARGET_DIR: ./public-dev
+
+      - name: "Deploy: Production"
+        run: make deploy
+        env:
+          S3_BUCKET: brandur.org
+          TARGET_DIR: ./public
+
+      - name: Upload photos
+        run: make photographs-upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWSSecretAccessKey }}
 
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Breaks GitHub Actions workflow that runs the deployment into a separate
deploy action that's contingent on our other checks. A little cleaner,
and ensures no deploy if lint or Tailwind was wrong.