### PR TITLE
Add another derived work for Base32 slugs

### DIFF
--- a/content/fragments/base32-slugs.md
+++ b/content/fragments/base32-slugs.md
@@ -50,6 +50,7 @@ So now when I list atoms from my filesystem or in S3, they come back in the same
 ## Derivatives (#derivatives)
 
 - This post inspired a [Rust crate](https://crates.io/crates/lexicoid).
+- It also inspired a [Ruby gem](https://rubygems.org/gems/lexicoid).
 
 [1] `math/big`'s integer `Bytes()` produces bytes in big-endian order (most significant byte first).
 [2] Character set is also downcased. Characters are easier to distinguish and it looks better.


### PR DESCRIPTION
This article came to mind recently when I had a need for behavior like this so I went ahead and wrote a Ruby library that implements it. I used the same name as Luciano (with permission!) because I liked it quite a bit and feel that "naming the concept" is a good thing.