### PR TITLE
Switch back to self-built ImageMagick + HEIC support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install ImageMagick
         run: |
           mkdir -p $(dirname "${{ env.MAGICK_BIN }}")
-          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/ImageMagick/ImageMagick/releases/download/${{ env.MAGICK_RELEASE }}/ImageMagick--clang-x86_64.AppImage
+          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/brandur/imagemagick-builder/releases/download/${{ env.MAGICK_RELEASE }}/magick
           chmod +x "${{ env.MAGICK_BIN }}"
 
       - name: ImageMagick format options
@@ -163,7 +163,7 @@ jobs:
       - name: Install ImageMagick
         run: |
           mkdir -p $(dirname "${{ env.MAGICK_BIN }}")
-          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/ImageMagick/ImageMagick/releases/download/${{ env.MAGICK_RELEASE }}/ImageMagick--clang-x86_64.AppImage
+          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/brandur/imagemagick-builder/releases/download/${{ env.MAGICK_RELEASE }}/magick
           chmod +x "${{ env.MAGICK_BIN }}"
 
       # See notes in check_and_test.
@@ -228,7 +228,7 @@ jobs:
       - name: Install ImageMagick
         run: |
           mkdir -p $(dirname "${{ env.MAGICK_BIN }}")
-          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/ImageMagick/ImageMagick/releases/download/${{ env.MAGICK_RELEASE }}/ImageMagick--clang-x86_64.AppImage
+          curl --compressed -L -o "${{ env.MAGICK_BIN }}" https://github.com/brandur/imagemagick-builder/releases/download/${{ env.MAGICK_RELEASE }}/magick
           chmod +x "${{ env.MAGICK_BIN }}"
 
       # See notes in check_and_test.


### PR DESCRIPTION
Worse than using the official release maybe, but comes with HEIC
support, and possibly a little faster since it's downloaded from GitHub
Actions.

Previously I'd been using a self-built binary, but started getting this
error:

    Run /home/runner/imagemagick/bin/magick identify -list format
    /home/runner/imagemagick/bin/magick: symbol lookup error: /home/runner/imagemagick/bin/magick: undefined symbol: heif_deinit

It appears that the cause was that I'd slipped to using a version of
libheif that was too old, and ImageMagick just has godawful error
messages. Since writing imagemagick-builder, it appears that the
repositories for libheif-dev and libde265-dev have been mainlined,
allowing me to decouple from the 3rd party repositories that I'd been
using and which had become outdated, and go to better maintained,
built-in versions [1]. Doing so fixed the problem above.

This patch also brings back support for HEIC.

[1] https://github.com/brandur/imagemagick-builder/commit/895a6a1b86b0144280b5fe348932b935f74a51b7