### PR TITLE
Dramatically reduce automated cron runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ on:
   pull_request:
   push:
   schedule:
-    # Once every 3 hours.
-    - cron: "0 */3 * * *"
+    # Once every 3 days.
+    - cron: "0 0 */3 * *"
 
 jobs:
   check_and_test:


### PR DESCRIPTION
Looking at my S3 bill last month (luckily, quite modest), the vast
majority of costs are for S3 list and mutation requests, which all come
from sorg builds, and mostly from its automated builds that run every 3
hours.

The automated builds made sense when the project was regularly updating
from third party data sources like Twitter, Strava, and Goodreads, but
as APIs have closed off one by one, its not actually pulling from any of
these projects anymore, leaving the automated builds an unnecessary
vestige.

Here, reduce frequency of automatic builds from every 3 hours to every 3
days. The new schedule is somewhat arbitrary, but premised on the logic
that somewhat regular runs are still a reasonably good idea to make sure
the build's still working in case I haven't pushed anything in a while.