### PR TITLE
Switch to `math/rand/v2`

### DIFF
--- a/build.go
+++ b/build.go
@@ -10,7 +10,7 @@ import (
 	"html/template"
 	"io"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
@@ -2992,7 +2992,7 @@ func selectRandomPhoto(photos []*Photo) *Photo {
 	}
 
 	//nolint:gosec
-	return randomPhotos[rand.Intn(len(randomPhotos))]
+	return randomPhotos[rand.IntN(len(randomPhotos))]
 }
 
 // Gets a pointer to a tag just to work around the fact that you can take the

--- a/modules/stemplate/stemplate.go
+++ b/modules/stemplate/stemplate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"path/filepath"
 	"strconv"
@@ -34,7 +34,7 @@ var FuncMap = template.FuncMap{
 	"NanoglyphSignup":         nanoglyphSignup,
 	"NumberWithDelimiter":     numberWithDelimiter,
 	"Pace":                    pace,
-	"RandIntn":                randIntn,
+	"RandIntN":                randIntN,
 	"RenderPublishingInfo":    renderPublishingInfo,
 	"RetinaImageAlt":          RetinaImageAlt,
 	"Sub":                     sub,
@@ -217,9 +217,9 @@ func pace(distance float64, duration time.Duration) string {
 	return fmt.Sprintf("%v:%02d", min, sec)
 }
 
-func randIntn(bound int) int {
+func randIntN(bound int) int {
 	//nolint:gosec
-	return rand.Intn(bound)
+	return rand.IntN(bound)
 }
 
 func renderPublishingInfo(info map[string]string) template.HTML {

--- a/modules/stemplate/stemplate_test.go
+++ b/modules/stemplate/stemplate_test.go
@@ -117,8 +117,8 @@ func TestPace(t *testing.T) {
 	assert.Equal(t, "7:31", pace(133.0, d))
 }
 
-func TestRandIntn(t *testing.T) {
-	assert.Equal(t, 0, randIntn(1))
+func TestRandIntN(t *testing.T) {
+	assert.Equal(t, 0, randIntN(1))
 }
 
 func TestRetinaImageAlt(t *testing.T) {

--- a/views/sequences/_entry.tmpl.html
+++ b/views/sequences/_entry.tmpl.html
@@ -16,20 +16,20 @@
         <div class="flex flex-col">
             <div class="mb-0.5">
                 {{- with (index .Entry.Photos 0) -}}
-                {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+                {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
                 {{- end -}}
             </div>
 
             <div class="md:flex md:flex-row md:mb-0.5">
                 <div class="mb-0.5 md:mr-0.5 md:mb-0">
                     {{- with (index .Entry.Photos 1) -}}
-                    {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+                    {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
                     {{- end -}}
                 </div>
 
                 <div class="mb-0.5 md:ml-0.5 md:mb-0">
                     {{- with (index .Entry.Photos 2) -}}
-                    {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+                    {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
                     {{- end -}}
                 </div>
             </div>
@@ -40,13 +40,13 @@
         <div class="md:flex md:flex-row mb-0.5">
             <div class="mb-0.5 mr-0.5 md:mb-0">
                 {{- with (index .Entry.Photos 0) -}}
-                {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+                {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
                 {{- end -}}
             </div>
 
             <div class="mb-0.5 ml-0.5 md:mb-0">
                 {{- with (index .Entry.Photos 1) -}}
-                {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+                {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
                 {{- end -}}
             </div>
         </div>
@@ -55,7 +55,7 @@
 
         <div class="mb-0.5">
             {{- with (index .Entry.Photos 0) -}}
-            {{LazyRetinaImageLightbox (RandIntn 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
+            {{LazyRetinaImageLightbox (RandIntN 100)  "/photographs/sequences/" (printf "%s_large" .Slug) .TargetExt .Portrait $linkOverride}}
             {{- end -}}
         </div>
 


### PR DESCRIPTION
Now upgraded to Go 1.22, switch to the new `math/rand/v2` package, which
promises a more consistent and safer API.