### PR TITLE
Update notifier.md

### DIFF
--- a/content/articles/notifier.md
+++ b/content/articles/notifier.md
@@ -136,7 +136,7 @@ func (l *Notifier) runOnce(ctx context.Context) error {
     // WaitForNotification is a blocking function, but since we want to wake
     // occasionally to process new `LISTEN`/`UNLISTEN` operations, we put a
     // context deadline on the listen, and as it expires don't treat it as an
-    // error unless it
+    // error unless it's unrelated to context expiration.
     notification, err := func() (*pgconn.Notification, error) {
         const listenTimeout = 30 * time.Second
 
@@ -170,13 +170,7 @@ func (l *Notifier) runOnce(ctx context.Context) error {
     l.mu.RLock()
     defer l.mu.RUnlock()
 
-    subs := l.subscriptions[notification.Channel]
-
-    if len(subs) < 1 {
-        return nil
-    }
-
-    for _, sub := range subs {
+    for _, sub := range l.subscriptions[notification.Channel] {
         sub.listenChan <- notification.Payload
     }
 

--- a/content/articles/notifier.md
+++ b/content/articles/notifier.md
@@ -170,6 +170,7 @@ func (l *Notifier) runOnce(ctx context.Context) error {
     l.mu.RLock()
     defer l.mu.RUnlock()
 
+    // Notify subscribers (this is a no-op if no subs/empty slice).
     for _, sub := range l.subscriptions[notification.Channel] {
         sub.listenChan <- notification.Payload
     }


### PR DESCRIPTION
Hi @brandur, I was reading over your awesome notifier post. I noticed a typo in a comment and figured I'd point it out. I also noticed something else I figured I'd ask about. I think the example code in `runOnce` can be simplified, since 1) the lock is held and 2) it's fine to range over nil slices. Is this strictly a style/convention, or if my proposed change has a bug/race condition, what am I missing?