### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,4 +281,4 @@ jobs:
       - name: "Check: golangci-lint"
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.59
+          version: v1.61

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 linters:
   disable:
+    # deprecated
+    - exportloopref
+
     # obnoxious
     - cyclop
     - depguard

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brandur/sorg
 
-go 1.22.0
+go 1.23
 
 // For debugging:
 // replace github.com/brandur/modulir => /Users/brandur/Documents/go/src/github.com/brandur/modulir


### PR DESCRIPTION
Not much to see here. Stay current on go to Go 1.23.