### PR TITLE
Have GitHub Actions only run on `master` branch pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ env:
 on:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     # Once a week on Tuesday.
     - cron: "0 0 * * TUE"


### PR DESCRIPTION
Have GitHub Actions only run on `master` branch pushes so that we don't
get doubled up runs with every pull request, which is quite irking.

The downside is that this will cause CI not to run for branches which
are pushed and which don't have a pull request.