### PR TITLE
Revert "Move conditional deploy job conditions from job to step (#378)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,11 +144,10 @@ jobs:
           echo "Please make sure that all Tailwind changes are checked in!"
           git diff --exit-code .
 
-  # Runs on all changes, but has a `skip` directive below so that nothing is
-  # actually deployed when not on master.
   deploy_dev:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: github.ref == 'refs/heads/master'
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
@@ -202,17 +201,15 @@ jobs:
           TARGET_DIR: ./public-dev
 
       - name: "Deploy: Development"
-        if: github.ref == 'refs/heads/master'
         run: make deploy
         env:
           S3_BUCKET: brandur.org-dev
           TARGET_DIR: ./public-dev
 
-  # Runs on all changes, but has a `skip` directive below so that nothing is
-  # actually deployed when not on master.
   deploy_prod:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: github.ref == 'refs/heads/master'
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWSAccessKeyID }}
@@ -265,14 +262,12 @@ jobs:
           TARGET_DIR: ./public
 
       - name: "Deploy: Production"
-        if: github.ref == 'refs/heads/master'
         run: make deploy
         env:
           S3_BUCKET: brandur.org
           TARGET_DIR: ./public
 
       - name: Upload photos
-        if: github.ref == 'refs/heads/master'
         run: make photographs-upload
 
   golangci-lint:


### PR DESCRIPTION
This reverts #378 / commit 0992fde96523613982384e71298240978309b1e7.

The deploy jobs run as dependencies after the first have run, and
although it looks better in the UI to succeed, having to wait for them
to finish adds another couple minutes to every pull request CI. Not
worth it.