### PR TITLE
Upgrade to Go 1.24 + golangci-lint 1.64.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,4 +288,4 @@ jobs:
       - name: "Check: golangci-lint"
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.61
+          version: v1.64.7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   disable:
     # deprecated
-    - exportloopref
+    - tenv
 
     # obnoxious
     - cyclop
@@ -16,7 +16,6 @@ linters:
     - goconst
     - gocyclo
     - godox
-    - gomnd
     - lll
     - mnd
     - nlreturn
@@ -24,9 +23,6 @@ linters:
     - testpackage
     - wsl
     - varnamelen
-
-    # buggy
-    - execinquery
   enable-all: true
 
 linters-settings:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brandur/sorg
 
-go 1.23
+go 1.24
 
 // For debugging:
 // replace github.com/brandur/modulir => /Users/brandur/Documents/go/src/github.com/brandur/modulir

--- a/send_test.go
+++ b/send_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -39,7 +38,7 @@ func TestMatchNewsletter(t *testing.T) {
 }
 
 func TestRenderAndSend(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	oldMailgunKey := conf.MailgunAPIKey
 	defer func() {


### PR DESCRIPTION
Regular upgrades to versions and change linters around based on what's
deprecated now.