### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,6 +286,6 @@ jobs:
           go-version-file: "go.mod"
 
       - name: "Check: golangci-lint"
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.7
+          version: v2.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,9 @@
-linters:
-  disable:
-    # deprecated
-    - tenv
+version: "2"
 
+linters:
+  default: all
+
+  disable:
     # obnoxious
     - cyclop
     - depguard
@@ -10,8 +11,8 @@ linters:
     - exhaustruct
     - forcetypeassert
     - funlen
-    - gochecknoinits
     - gochecknoglobals
+    - gochecknoinits
     - gocognit
     - goconst
     - gocyclo
@@ -21,30 +22,45 @@ linters:
     - nlreturn
     - paralleltest
     - testpackage
-    - wsl
     - varnamelen
-  enable-all: true
+    - wsl
 
-linters-settings:
-  forbidigo:
-    forbid:
-      - '^errors\.Wrap$'
-      - '^errors\.Wrapf$'
-      - '^fmt\.Errorf$'
-  gci:
-    sections:
-      - Standard
-      - Default
-      - Prefix(github.com/brandur)
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^errors\.Wrap$
+        - pattern: ^errors\.Wrapf$
+        - pattern: ^fmt\.Errorf$
 
-  gocritic:
-    disabled-checks:
-      - commentFormatting
+    gocritic:
+      disabled-checks:
+        - commentFormatting
 
-  gosec:
-    excludes:
-      - G203
+    gosec:
+      excludes:
+        - G203
 
-  wrapcheck:
-    ignorePackageGlobs:
-      - github.com/brandur/*
+    wrapcheck:
+      ignore-package-globs:
+        - github.com/brandur/*
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/brandur)

--- a/modules/stemplate/stemplate_test.go
+++ b/modules/stemplate/stemplate_test.go
@@ -87,7 +87,7 @@ func TestMonthName(t *testing.T) {
 func TestNanoglyphSignup(t *testing.T) {
 	t.Run("InEmail", func(t *testing.T) {
 		str := nanoglyphSignup(true)
-		assert.Equal(t, "", string(str))
+		assert.Empty(t, string(str))
 	})
 
 	t.Run("NotEmail", func(t *testing.T) {
@@ -132,13 +132,13 @@ func TestRound(t *testing.T) {
 }
 
 func TestToStars(t *testing.T) {
-	assert.Equal(t, "", toStars(0))
+	assert.Empty(t, toStars(0))
 	assert.Equal(t, "★ ", toStars(1))
 	assert.Equal(t, "★ ★ ★ ★ ★ ", toStars(5))
 }
 
 func TestURLBaseExt(t *testing.T) {
-	assert.Equal(t, "", urlBaseExt("https://example.com/video"))
+	assert.Empty(t, urlBaseExt("https://example.com/video"))
 	assert.Equal(t, "jpg", urlBaseExt("https://example.com/image.JPG"))
 	assert.Equal(t, "mp4", urlBaseExt("https://example.com/video.mp4"))
 	assert.Equal(t, "webm", urlBaseExt("https://example.com/video.webm"))

--- a/modules/stoc/stoc_test.go
+++ b/modules/stoc/stoc_test.go
@@ -189,7 +189,7 @@ func TestRender(t *testing.T) {
 func TestRenderEmpty(t *testing.T) {
 	rendered, err := Render("hello")
 	assert.NoError(t, err)
-	assert.Equal(t, "", rendered)
+	assert.Empty(t, rendered)
 }
 
 //


### PR DESCRIPTION
Upgrade to golangci-lint v2, released yesterday. Mostly involves a
restructuring of the configuration file.